### PR TITLE
feat(registry): Create v0 Registry contract

### DIFF
--- a/abis/Registry.ts
+++ b/abis/Registry.ts
@@ -1,28 +1,40 @@
 export const registryContractAbi = [
   {
-    anonymous: false,
     inputs: [
       {
-        indexed: true,
         internalType: 'string',
         name: 'protocolId',
         type: 'string',
       },
       {
-        indexed: true,
+        internalType: 'string',
+        name: 'referrerId',
+        type: 'string',
+      },
+    ],
+    name: 'ReferrerNotRegistered',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'string',
+        name: 'protocolId',
+        type: 'string',
+      },
+      {
         internalType: 'string',
         name: 'referrerId',
         type: 'string',
       },
       {
-        indexed: true,
         internalType: 'address',
         name: 'userAddress',
         type: 'address',
       },
     ],
-    name: 'ReferralRegistered',
-    type: 'event',
+    name: 'UserAlreadyRegistered',
+    type: 'error',
   },
   {
     anonymous: false,
@@ -46,7 +58,7 @@ export const registryContractAbi = [
         type: 'address',
       },
     ],
-    name: 'ReferralSkipped',
+    name: 'ReferralRegistered',
     type: 'event',
   },
   {
@@ -94,6 +106,25 @@ export const registryContractAbi = [
         internalType: 'string[]',
         name: '',
         type: 'string[]',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'string',
+        name: 'referrerId',
+        type: 'string',
+      },
+    ],
+    name: 'getRewardAddress',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
       },
     ],
     stateMutability: 'view',

--- a/abis/Registry.ts
+++ b/abis/Registry.ts
@@ -96,6 +96,25 @@ export const registryContractAbi = [
     inputs: [
       {
         internalType: 'string',
+        name: 'referrerId',
+        type: 'string',
+      },
+    ],
+    name: 'getProtocols',
+    outputs: [
+      {
+        internalType: 'string[]',
+        name: '',
+        type: 'string[]',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'string',
         name: 'protocolId',
         type: 'string',
       },

--- a/abis/Registry.ts
+++ b/abis/Registry.ts
@@ -1,0 +1,201 @@
+export const registryContractAbi = [
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'string',
+        name: 'protocolId',
+        type: 'string',
+      },
+      {
+        indexed: true,
+        internalType: 'string',
+        name: 'referrerId',
+        type: 'string',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'userAddress',
+        type: 'address',
+      },
+    ],
+    name: 'ReferralRegistered',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'string',
+        name: 'protocolId',
+        type: 'string',
+      },
+      {
+        indexed: true,
+        internalType: 'string',
+        name: 'referrerId',
+        type: 'string',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'userAddress',
+        type: 'address',
+      },
+    ],
+    name: 'ReferralSkipped',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'string',
+        name: 'referrerId',
+        type: 'string',
+      },
+      {
+        indexed: true,
+        internalType: 'string[]',
+        name: 'protocolIds',
+        type: 'string[]',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256[]',
+        name: 'rewardRates',
+        type: 'uint256[]',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'rewardAddress',
+        type: 'address',
+      },
+    ],
+    name: 'ReferrerRegistered',
+    type: 'event',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'string',
+        name: 'protocolId',
+        type: 'string',
+      },
+    ],
+    name: 'getReferrers',
+    outputs: [
+      {
+        internalType: 'string[]',
+        name: '',
+        type: 'string[]',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'string',
+        name: 'protocolId',
+        type: 'string',
+      },
+      {
+        internalType: 'string',
+        name: 'referrerId',
+        type: 'string',
+      },
+    ],
+    name: 'getRewardRate',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'string',
+        name: 'protocolId',
+        type: 'string',
+      },
+      {
+        internalType: 'string',
+        name: 'referrerId',
+        type: 'string',
+      },
+    ],
+    name: 'getUsers',
+    outputs: [
+      {
+        internalType: 'address[]',
+        name: '',
+        type: 'address[]',
+      },
+      {
+        internalType: 'uint256[]',
+        name: '',
+        type: 'uint256[]',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'string',
+        name: 'referrerId',
+        type: 'string',
+      },
+      {
+        internalType: 'string',
+        name: 'protocolId',
+        type: 'string',
+      },
+    ],
+    name: 'registerReferral',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'string',
+        name: '_referrerId',
+        type: 'string',
+      },
+      {
+        internalType: 'string[]',
+        name: '_protocolIds',
+        type: 'string[]',
+      },
+      {
+        internalType: 'uint256[]',
+        name: '_rewardRates',
+        type: 'uint256[]',
+      },
+      {
+        internalType: 'address',
+        name: '_rewardAddress',
+        type: 'address',
+      },
+    ],
+    name: 'registerReferrer',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+]

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -81,9 +81,9 @@ contract Registry is AccessControlDefaultAdminRules {
     string calldata protocolId
   ) external {
     // Check if the referrer has been initialized but the user has not been registered before to the given protocol
-    if (_referrers[protocolId][referrerId].rewardAddress != address(0)) {
+    if (_referrers[protocolId][referrerId].rewardAddress == address(0)) {
       revert ReferrerNotRegistered(protocolId, referrerId);
-    } else if (_usersByProtocol[protocolId][msg.sender].timestamp == 0) {
+    } else if (_usersByProtocol[protocolId][msg.sender].timestamp != 0) {
       revert UserAlreadyRegistered(protocolId, referrerId, msg.sender);
     } else {
       _usersByReferrer[protocolId][referrerId][msg.sender] = User(

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -59,7 +59,7 @@ contract Registry is AccessControlDefaultAdminRules {
     uint256[] calldata rewardRates,
     address rewardAddress
   ) external onlyRole(DEFAULT_ADMIN_ROLE) {
-    // Remove referrer from protocols where the relationship is no longer active (from previous registration)
+    // Remove referrer from protocols from previous registrations
     for (uint256 i = 0; i < _referrerIdToProtocolIds[referrerId].length; i++) {
       string memory protocol = _referrerIdToProtocolIds[referrerId][i];
       string[] storage referrerIds = _protocolIdToReferrerIds[protocol];

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {AccessControlDefaultAdminRules} from '@openzeppelin/contracts/access/extensions/AccessControlDefaultAdminRules.sol';
+import {SafeERC20} from '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
+import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+
+contract Registry is AccessControlDefaultAdminRules {
+  using SafeERC20 for IERC20;
+
+  event ReferrerRegistered(
+    string indexed referrerId,
+    string[] indexed protocolIds,
+    uint256[] rewardRates,
+    address rewardAddress
+  );
+
+  event ReferralRegistered(
+    string indexed protocolId,
+    string indexed referrerId,
+    address indexed userAddress
+  );
+  
+  event ReferralSkipped(
+    string indexed protocolId,
+    string indexed referrerId,
+    address indexed userAddress
+  );
+
+  struct User {
+    uint256 timestamp;
+  }
+
+  struct Referrer {
+    address rewardAddress;
+    uint256 rewardRate;
+    address[] userAddresses;
+  }
+
+  struct Protocol {
+    string[] _referrers;
+  }
+
+  mapping(string => Protocol) private _protocols;
+  mapping(string => mapping(string => Referrer)) private _referrers;
+  mapping(string => mapping(string => mapping(address => User))) private _users;
+
+  constructor(
+    address owner,
+    uint48 transferDelay
+  ) AccessControlDefaultAdminRules(transferDelay, owner) {}
+
+  function registerReferrer(
+    string calldata _referrerId,
+    string[] calldata _protocolIds,
+    uint256[] calldata _rewardRates,
+    address _rewardAddress
+  ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    for (uint256 i = 0; i < _protocolIds.length; i++) {
+      _referrers[_protocolIds[i]][_referrerId] = Referrer(
+        _rewardAddress,
+        _rewardRates[i],
+        new address[](0)
+      );
+      _protocols[_protocolIds[i]]._referrers.push(_referrerId);
+    }
+    emit ReferrerRegistered(_referrerId, _protocolIds, _rewardRates, _rewardAddress);
+  }
+
+  function registerReferral(
+    string calldata referrerId,
+    string calldata protocolId
+  ) external {
+    if (
+      // Check if the referrer has been initialized but the user has not been registered before
+      _referrers[protocolId][referrerId].rewardAddress != address(0) &&
+      _users[protocolId][referrerId][msg.sender].timestamp == 0
+    ) {
+      _users[protocolId][referrerId][msg.sender] = User(block.timestamp);
+      _referrers[protocolId][referrerId].userAddresses.push(msg.sender);
+      emit ReferralRegistered(protocolId, referrerId, msg.sender);
+    } else {
+      emit ReferralSkipped(protocolId, referrerId, msg.sender);
+    }
+  }
+
+  function getReferrers(
+    string calldata protocolId
+  ) external view returns (string[] memory) {
+    return _protocols[protocolId]._referrers;
+  }
+
+  function getUsers(
+    string calldata protocolId,
+    string calldata referrerId
+  ) external view returns (address[] memory, uint256[] memory) {
+    address[] memory userAddresses = _referrers[protocolId][referrerId]
+      .userAddresses;
+    uint256[] memory timestamps = new uint256[](userAddresses.length);
+
+    for (uint256 i = 0; i < userAddresses.length; i++) {
+      timestamps[i] = _users[protocolId][referrerId][userAddresses[i]].timestamp;
+    }
+
+    return (userAddresses, timestamps);
+  }
+
+  function getRewardRate(
+    string calldata protocolId,
+    string calldata referrerId
+  ) external view returns (uint256) {
+    return _referrers[protocolId][referrerId].rewardRate;
+  }
+}

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -10,7 +10,7 @@ contract Registry is AccessControlDefaultAdminRules {
 
   event ReferrerRegistered(
     string indexed referrerId,
-    string[] indexed protocolIds,
+    string[] protocolIds,
     uint256[] rewardRates,
     address rewardAddress
   );

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -76,6 +76,8 @@ contract Registry is AccessControlDefaultAdminRules {
         }
       }
     }
+    // Reset the list of protocols for the referrer
+    _referrerIdToProtocolIds[referrerId] = new string[](0);
     // Add/update the reward rate for each protocol, add the referrer to the list of referrers for each protocol
     for (uint256 i = 0; i < protocolIds.length; i++) {
       _referrerInfoByProtocol[protocolIds[i]][referrerId]

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -81,7 +81,7 @@ contract Registry is AccessControlDefaultAdminRules {
       _referrerInfoByProtocol[protocolIds[i]][referrerId]
         .rewardRate = rewardRates[i];
       _protocolIdToReferrerIds[protocolIds[i]].push(referrerId);
-      // Update the list of protocols for the referrer (need to copy each element individually, cannot just assing the array)
+      // Update the list of protocols for the referrer (need to copy each element individually, cannot just assign the array)
       _referrerIdToProtocolIds[referrerId].push(protocolIds[i]);
     }
     // Update/add the reward address for the referrer

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -45,8 +45,6 @@ contract Registry is AccessControlDefaultAdminRules {
 
   mapping(string => Protocol) private _protocols;
   mapping(string => mapping(string => Referrer)) private _referrers;
-  mapping(string => mapping(string => mapping(address => User)))
-    private _usersByReferrer;
   mapping(string => mapping(address => User)) private _usersByProtocol;
 
   constructor(
@@ -86,9 +84,6 @@ contract Registry is AccessControlDefaultAdminRules {
     } else if (_usersByProtocol[protocolId][msg.sender].timestamp != 0) {
       revert UserAlreadyRegistered(protocolId, referrerId, msg.sender);
     } else {
-      _usersByReferrer[protocolId][referrerId][msg.sender] = User(
-        block.timestamp
-      );
       _usersByProtocol[protocolId][msg.sender] = User(block.timestamp);
       _referrers[protocolId][referrerId].userAddresses.push(msg.sender);
       emit ReferralRegistered(protocolId, referrerId, msg.sender);
@@ -110,7 +105,7 @@ contract Registry is AccessControlDefaultAdminRules {
     uint256[] memory timestamps = new uint256[](userAddresses.length);
 
     for (uint256 i = 0; i < userAddresses.length; i++) {
-      timestamps[i] = _usersByReferrer[protocolId][referrerId][userAddresses[i]]
+      timestamps[i] = _usersByProtocol[protocolId][userAddresses[i]]
         .timestamp;
     }
 

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -76,7 +76,7 @@ contract Registry is AccessControlDefaultAdminRules {
         }
       }
     }
-    // Add/update the reward rate for each provider, add the referrer to the list of referrers for each provider
+    // Add/update the reward rate for each protocol, add the referrer to the list of referrers for each protocol
     for (uint256 i = 0; i < protocolIds.length; i++) {
       _referrerInfoByProtocol[protocolIds[i]][referrerId]
         .rewardRate = rewardRates[i];
@@ -127,6 +127,12 @@ contract Registry is AccessControlDefaultAdminRules {
     string calldata protocolId
   ) external view returns (string[] memory) {
     return _protocolIdToReferrerIds[protocolId];
+  }
+
+  function getProtocols(
+    string calldata providerId
+  ) external view returns (string[] memory) {
+    return _referrerIdToProtocolIds[providerId];
   }
 
   function getUsers(

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "eslint": "^8.57.0",
     "eslint-import-resolver-typescript": "^3.7.0",
     "eslint-plugin-import": "^2.29.1",
+    "ethers": "^6.13.5",
     "hardhat": "^2.22.17",
     "hardhat-gas-reporter": "^2.2.2",
     "jest": "^29.7.0",

--- a/test/Registry.ts
+++ b/test/Registry.ts
@@ -104,13 +104,12 @@ describe(REGISTRY_CONTRACT_NAME, function () {
       )
 
       // Re-register the referrer with the different protocolIds
-      await expect(
+      await
         registry.registerReferrer(
           mockReferrerId,
           [mockProtocolId2],
           mockRewardRates,
           mockRewardAddress2,
-        ),
       )
       // Check that the referrer is no longer registered to protocol1
       const referrersProtocol1 = await registry.getReferrers(mockProtocolId)

--- a/test/Registry.ts
+++ b/test/Registry.ts
@@ -8,6 +8,7 @@ const mockRewardAddress = getAddress(
   '0x471EcE3750Da237f93B8E339c536989b8978a499'.toLowerCase(),
 )
 const mockReferrerId = 'referrer1'
+const mockReferrerId2 = 'referrer2'
 const mockProtocolId = 'protocol1'
 const mockRewardRates = [10]
 
@@ -161,7 +162,7 @@ describe(REGISTRY_CONTRACT_NAME, function () {
       await expect(
         registry
           .connect(addr1)
-          .registerReferral(mockReferrerId, mockProtocolId),
+          .registerReferral(mockReferrerId2, mockProtocolId),
       )
         .to.emit(registry, 'ReferralSkipped')
         .withArgs(mockProtocolId, mockReferrerId, addr1.address)

--- a/test/Registry.ts
+++ b/test/Registry.ts
@@ -116,6 +116,9 @@ describe(REGISTRY_CONTRACT_NAME, function () {
       // Check that the referrer is now registered to protocol2
       const referrersProtocol2 = await registry.getReferrers(mockProtocolId2)
       expect(referrersProtocol2).to.deep.equal([mockReferrerId])
+      // Check that the protocol(s) for the referrer has been updated
+      const protocols = await registry.getProtocols(mockReferrerId)
+      expect(protocols).to.deep.equal([mockProtocolId2])
       // Check that the referrer's reward address has been updated
       const rewardAddress = await registry.getRewardAddress(mockReferrerId)
       expect(rewardAddress).to.equal(mockRewardAddress2)
@@ -224,19 +227,19 @@ describe(REGISTRY_CONTRACT_NAME, function () {
     })
 
     it('should return protocols for a referrer', async function () {
-        const { registry } = await deployRegistryContract()
-        const protocolIds = [mockProtocolId]
-  
-        await registry.registerReferrer(
-          mockReferrerId,
-          protocolIds,
-          mockRewardRates,
-          mockRewardAddress,
-        )
-  
-        const protocols = await registry.getProtocols(mockReferrerId)
-        expect(protocols).to.deep.equal([mockProtocolId])
-      })
+      const { registry } = await deployRegistryContract()
+      const protocolIds = [mockProtocolId]
+
+      await registry.registerReferrer(
+        mockReferrerId,
+        protocolIds,
+        mockRewardRates,
+        mockRewardAddress,
+      )
+
+      const protocols = await registry.getProtocols(mockReferrerId)
+      expect(protocols).to.deep.equal([mockProtocolId])
+    })
 
     it('should return users and their timestamps', async function () {
       const { registry, addr1 } = await deployRegistryContract()

--- a/test/Registry.ts
+++ b/test/Registry.ts
@@ -30,15 +30,15 @@ describe(REGISTRY_CONTRACT_NAME, function () {
       const rewardRates = [10]
 
       await expect(
-        await registry
-          .registerReferrer(
+        (
+          await registry.registerReferrer(
             referrerId,
             protocolIds,
             rewardRates,
             mockRewardAddress,
           )
-
-          .to.emit(registry, 'ReferrerRegistered')
+        ).to
+          .emit(registry, 'ReferrerRegistered')
           .withArgs(referrerId, protocolIds, rewardRates, mockRewardAddress),
       )
 
@@ -56,15 +56,16 @@ describe(REGISTRY_CONTRACT_NAME, function () {
 
       // Non-owner (addr1) should not be able to register the referrer
       await expect(
-        await registry
-          .connect(addr1)
-          .registerReferrer(
-            referrerId,
-            protocolIds,
-            rewardRates,
-            mockRewardAddress,
-          )
-          .to.be.rejectedWith('AccessControlUnauthorizedAccount'),
+        (
+          await registry
+            .connect(addr1)
+            .registerReferrer(
+              referrerId,
+              protocolIds,
+              rewardRates,
+              mockRewardAddress,
+            )
+        ).to.be.rejectedWith('AccessControlUnauthorizedAccount'),
       )
     })
   })
@@ -83,10 +84,10 @@ describe(REGISTRY_CONTRACT_NAME, function () {
       )
 
       await expect(
-        await registry
-          .connect(addr1)
-          .registerReferral(referrerId, protocolId)
-          .to.emit(registry, 'ReferralRegistered')
+        (
+          await registry.connect(addr1).registerReferral(referrerId, protocolId)
+        ).to
+          .emit(registry, 'ReferralRegistered')
           .withArgs(protocolId, referrerId, addr1.address),
       )
 
@@ -103,10 +104,10 @@ describe(REGISTRY_CONTRACT_NAME, function () {
       const protocolId = 'protocol1'
 
       await expect(
-        await registry
-          .connect(addr1)
-          .registerReferral(referrerId, protocolId)
-          .to.emit(registry, 'ReferralSkipped')
+        (
+          await registry.connect(addr1).registerReferral(referrerId, protocolId)
+        ).to
+          .emit(registry, 'ReferralSkipped')
           .withArgs(protocolId, referrerId, addr1.address),
       )
     })
@@ -126,10 +127,10 @@ describe(REGISTRY_CONTRACT_NAME, function () {
 
       // Trying to register again should emit "ReferralSkipped"
       await expect(
-        await registry
-          .connect(addr1)
-          .registerReferral(referrerId, protocolId)
-          .to.emit(registry, 'ReferralSkipped')
+        (
+          await registry.connect(addr1).registerReferral(referrerId, protocolId)
+        ).to
+          .emit(registry, 'ReferralSkipped')
           .withArgs(protocolId, referrerId, addr1.address),
       )
     })

--- a/test/Registry.ts
+++ b/test/Registry.ts
@@ -52,6 +52,42 @@ describe(REGISTRY_CONTRACT_NAME, function () {
       const referrers = await registry.getReferrers(mockProtocolId)
       expect(referrers).to.deep.equal([mockReferrerId])
     })
+    it('should register a referrer with multiple protocolIds', async function () {
+      const { registry } = await deployRegistryContract()
+      const protocolIds = ['protocol1', 'protocol2']
+      const rewardRates = [10, 20]
+
+      await expect(
+        registry.registerReferrer(
+          mockReferrerId,
+          protocolIds,
+          rewardRates,
+          mockRewardAddress,
+        ),
+      )
+        .to.emit(registry, 'ReferrerRegistered')
+        .withArgs(mockReferrerId, protocolIds, rewardRates, mockRewardAddress)
+
+      // Check that the referrer was registered correctly to protocol1
+      const rewardRate1 = await registry.getRewardRate(
+        'protocol1',
+        mockReferrerId,
+      )
+      expect(rewardRate1).to.equal(10)
+
+      const referrersProtocol1 = await registry.getReferrers('protocol1')
+      expect(referrersProtocol1).to.deep.equal([mockReferrerId])
+
+      // Check that the referrer was registered correctly to protocol2
+      const rewardRate2 = await registry.getRewardRate(
+        'protocol2',
+        mockReferrerId,
+      )
+      expect(rewardRate2).to.equal(20)
+
+      const referrersProtocol2 = await registry.getReferrers('protocol2')
+      expect(referrersProtocol2).to.deep.equal([mockReferrerId])
+    })
     it('should allow only the owner to register a referrer', async function () {
       const { registry, addr1 } = await deployRegistryContract()
       const protocolIds = [mockProtocolId]

--- a/test/Registry.ts
+++ b/test/Registry.ts
@@ -7,59 +7,63 @@ const REGISTRY_CONTRACT_NAME = 'Registry'
 const mockRewardAddress = getAddress(
   '0x471EcE3750Da237f93B8E339c536989b8978a499'.toLowerCase(),
 )
+const mockReferrerId = 'referrer1'
+const mockProtocolId = 'protocol1'
+const mockRewardRates = [0.1]
 
 describe(REGISTRY_CONTRACT_NAME, function () {
-  let Registry
-  let registry
-  let owner
-  let addr1
-
-  beforeEach(async () => {
-    // Get the signers
-    ;[owner, addr1] = await hre.ethers.getSigners()
+  async function deployRegistryContract() {
+    const [_owner, addr1] = await hre.ethers.getSigners()
 
     // Deploy the Registry contract
-    Registry = await hre.ethers.getContractFactory(REGISTRY_CONTRACT_NAME)
-    registry = await Registry.deploy(owner.address, 0)
-  })
+    const Registry = await hre.ethers.getContractFactory(REGISTRY_CONTRACT_NAME)
+    const registry = await Registry.deploy(_owner.address, 0)
+    return { registry, addr1 }
+  }
 
   describe('Referrer Registration', function () {
     it('should register a referrer correctly', async function () {
-      const referrerId = 'referrer1'
-      const protocolIds = ['protocol1']
-      const rewardRates = [10]
+      const { registry } = await deployRegistryContract()
+      const protocolIds = [mockProtocolId]
 
       await expect(
         registry.registerReferrer(
-          referrerId,
+          mockReferrerId,
           protocolIds,
-          rewardRates,
+          mockRewardRates,
           mockRewardAddress,
         ),
       )
         .to.emit(registry, 'ReferrerRegistered')
-        .withArgs(referrerId, protocolIds, rewardRates, mockRewardAddress)
+        .withArgs(
+          mockReferrerId,
+          protocolIds,
+          mockRewardRates,
+          mockRewardAddress,
+        )
 
       // Check that the referrer was registered correctly
-      const referrer = await registry.getRewardRate('protocol1', referrerId)
+      const referrer = await registry.getRewardRate(
+        mockProtocolId,
+        mockReferrerId,
+      )
       expect(referrer).to.equal(10)
 
-      const referrers = await registry.getReferrers('protocol1')
-      expect(referrers).to.deep.equal([referrerId])
+      const referrers = await registry.getReferrers(mockProtocolId)
+      expect(referrers).to.deep.equal([mockReferrerId])
     })
     it('should allow only the owner to register a referrer', async function () {
-      const referrerId = 'referrer1'
-      const protocolIds = ['protocol1']
-      const rewardRates = [10]
+      const { registry, addr1 } = await deployRegistryContract()
+      const protocolIds = [mockProtocolId]
 
       // Non-owner (addr1) should not be able to register the referrer
       await expect(
         registry
           .connect(addr1)
           .registerReferrer(
-            referrerId,
+            mockReferrerId,
             protocolIds,
-            rewardRates,
+            mockRewardRates,
             mockRewardAddress,
           ),
       ).to.be.rejectedWith('AccessControlUnauthorizedAccount')
@@ -68,97 +72,97 @@ describe(REGISTRY_CONTRACT_NAME, function () {
 
   describe('Referral Registration', function () {
     it('should register a referral when referrer exists', async function () {
-      const referrerId = 'referrer1'
-      const protocolId = 'protocol1'
-      const rewardRates = [10]
+      const { registry, addr1 } = await deployRegistryContract()
 
       await registry.registerReferrer(
-        referrerId,
-        [protocolId],
-        rewardRates,
+        mockReferrerId,
+        [mockProtocolId],
+        mockRewardRates,
         mockRewardAddress,
       )
 
       await expect(
-        registry.connect(addr1).registerReferral(referrerId, protocolId),
+        registry
+          .connect(addr1)
+          .registerReferral(mockReferrerId, mockProtocolId),
       )
         .to.emit(registry, 'ReferralRegistered')
-        .withArgs(protocolId, referrerId, addr1.address)
+        .withArgs(mockProtocolId, mockReferrerId, addr1.address)
 
       const [userAddresses, timestamps] = await registry.getUsers(
-        protocolId,
-        referrerId,
+        mockProtocolId,
+        mockReferrerId,
       )
       expect(userAddresses).to.include(addr1.address)
       expect(timestamps[0]).to.be.above(0)
     })
 
     it('should skip referral if the referrer does not exist', async function () {
+      const { registry, addr1 } = await deployRegistryContract()
       const referrerId = 'referrerNotExist'
-      const protocolId = 'protocol1'
 
       await expect(
-        registry.connect(addr1).registerReferral(referrerId, protocolId),
+        registry.connect(addr1).registerReferral(referrerId, mockProtocolId),
       )
         .to.emit(registry, 'ReferralSkipped')
-        .withArgs(protocolId, referrerId, addr1.address)
+        .withArgs(mockProtocolId, referrerId, addr1.address)
     })
 
     it('should skip referral if the user is already registered', async function () {
-      const referrerId = 'referrer1'
-      const protocolId = 'protocol1'
-      const rewardRates = [10]
+      const { registry, addr1 } = await deployRegistryContract()
 
       await registry.registerReferrer(
-        referrerId,
-        [protocolId],
-        rewardRates,
+        mockReferrerId,
+        [mockProtocolId],
+        mockRewardRates,
         mockRewardAddress,
       )
-      await registry.connect(addr1).registerReferral(referrerId, protocolId)
+      await registry
+        .connect(addr1)
+        .registerReferral(mockReferrerId, mockProtocolId)
 
       // Trying to register again should emit "ReferralSkipped"
       await expect(
-        registry.connect(addr1).registerReferral(referrerId, protocolId),
+        registry
+          .connect(addr1)
+          .registerReferral(mockReferrerId, mockProtocolId),
       )
         .to.emit(registry, 'ReferralSkipped')
-        .withArgs(protocolId, referrerId, addr1.address)
+        .withArgs(mockProtocolId, mockReferrerId, addr1.address)
     })
   })
 
   describe('Getters', function () {
     it('should return referrers for a protocol', async function () {
-      const referrerId = 'referrer1'
-      const protocolIds = ['protocol1']
-      const rewardRates = [10]
+      const { registry } = await deployRegistryContract()
+      const protocolIds = [mockProtocolId]
 
       await registry.registerReferrer(
-        referrerId,
+        mockReferrerId,
         protocolIds,
-        rewardRates,
+        mockRewardRates,
         mockRewardAddress,
       )
 
-      const referrers = await registry.getReferrers('protocol1')
-      expect(referrers).to.deep.equal([referrerId])
+      const referrers = await registry.getReferrers(mockProtocolId)
+      expect(referrers).to.deep.equal([mockReferrerId])
     })
 
     it('should return users and their timestamps', async function () {
-      const referrerId = 'referrer1'
-      const protocolId = 'protocol1'
-      const rewardRates = [10]
-
+      const { registry, addr1 } = await deployRegistryContract()
       await registry.registerReferrer(
-        referrerId,
-        [protocolId],
-        rewardRates,
+        mockReferrerId,
+        [mockProtocolId],
+        mockRewardRates,
         mockRewardAddress,
       )
 
-      await registry.connect(addr1).registerReferral(referrerId, protocolId)
+      await registry
+        .connect(addr1)
+        .registerReferral(mockReferrerId, mockProtocolId)
       const [userAddresses, timestamps] = await registry.getUsers(
-        protocolId,
-        referrerId,
+        mockProtocolId,
+        mockReferrerId,
       )
 
       expect(userAddresses).to.include(addr1.address)
@@ -166,19 +170,20 @@ describe(REGISTRY_CONTRACT_NAME, function () {
     })
 
     it('should return the correct reward rate', async function () {
-      const referrerId = 'referrer1'
-      const protocolId = 'protocol1'
-      const rewardRates = [10]
+      const { registry } = await deployRegistryContract()
 
       await registry.registerReferrer(
-        referrerId,
-        [protocolId],
-        rewardRates,
+        mockReferrerId,
+        [mockProtocolId],
+        mockRewardRates,
         mockRewardAddress,
       )
 
-      const rewardRate = await registry.getRewardRate(protocolId, referrerId)
-      expect(rewardRate).to.equal(10)
+      const rewardRate = await registry.getRewardRate(
+        mockProtocolId,
+        mockReferrerId,
+      )
+      expect(rewardRate).to.equal(mockRewardRates[0])
     })
   })
 })

--- a/test/Registry.ts
+++ b/test/Registry.ts
@@ -13,11 +13,10 @@ describe(REGISTRY_CONTRACT_NAME, function () {
   let registry
   let owner
   let addr1
-  let _addr2
 
   beforeEach(async () => {
     // Get the signers
-    ;[owner, addr1, _addr2] = await hre.ethers.getSigners()
+    [owner, addr1] = await hre.ethers.getSigners()
 
     // Deploy the Registry contract
     Registry = await hre.ethers.getContractFactory(REGISTRY_CONTRACT_NAME)

--- a/test/Registry.ts
+++ b/test/Registry.ts
@@ -16,7 +16,7 @@ describe(REGISTRY_CONTRACT_NAME, function () {
 
   beforeEach(async () => {
     // Get the signers
-    ;[owner, addr1] = await hre.ethers.getSigners()
+    [owner, addr1] = await hre.ethers.getSigners()
 
     // Deploy the Registry contract
     Registry = await hre.ethers.getContractFactory(REGISTRY_CONTRACT_NAME)

--- a/test/Registry.ts
+++ b/test/Registry.ts
@@ -9,7 +9,7 @@ const mockRewardAddress = getAddress(
 )
 const mockReferrerId = 'referrer1'
 const mockProtocolId = 'protocol1'
-const mockRewardRates = [0.1]
+const mockRewardRates = [10]
 
 describe(REGISTRY_CONTRACT_NAME, function () {
   async function deployRegistryContract() {

--- a/test/Registry.ts
+++ b/test/Registry.ts
@@ -104,12 +104,11 @@ describe(REGISTRY_CONTRACT_NAME, function () {
       )
 
       // Re-register the referrer with the different protocolIds
-      await
-        registry.registerReferrer(
-          mockReferrerId,
-          [mockProtocolId2],
-          mockRewardRates,
-          mockRewardAddress2,
+      await registry.registerReferrer(
+        mockReferrerId,
+        [mockProtocolId2],
+        mockRewardRates,
+        mockRewardAddress2,
       )
       // Check that the referrer is no longer registered to protocol1
       const referrersProtocol1 = await registry.getReferrers(mockProtocolId)

--- a/test/Registry.ts
+++ b/test/Registry.ts
@@ -1,27 +1,35 @@
 import { expect } from 'chai'
 import hre from 'hardhat'
+import { getAddress } from 'ethers'
 
 const REGISTRY_CONTRACT_NAME = 'Registry'
+const REWARD_TOKEN_CONTRACT_NAME = 'MockErc20'
+
+const mockRewardTokenAddress = getAddress(
+    '0x471EcE3750Da237f93B8E339c536989b8978a499'.toLowerCase(),
+  )
 
 describe(REGISTRY_CONTRACT_NAME, function () {
   let Registry
   let registry
   let owner
   let addr1
-  let addr2
+  let _addr2
   let token
 
   beforeEach(async () => {
     // Get the signers
-    ;[owner, addr1, addr2] = await hre.ethers.getSigners()
+    [owner, addr1, _addr2] = await hre.ethers.getSigners()
 
     // Deploy the Registry contract
     Registry = await hre.ethers.getContractFactory(REGISTRY_CONTRACT_NAME)
     registry = await Registry.deploy(owner.address, 0)
 
     // Create a mock ERC20 token to use as reward token
-    const ERC20 = await hre.ethers.getContractFactory('ERC20')
-    token = await ERC20.deploy('Mock Token', 'MTK', 1000000)
+    const RewardToken = await hre.ethers.getContractFactory(
+        REWARD_TOKEN_CONTRACT_NAME,
+      )
+      const token = await RewardToken.deploy('FOO', 'BAR')
   })
 
   describe('Referrer Registration', function () {

--- a/test/Registry.ts
+++ b/test/Registry.ts
@@ -141,8 +141,8 @@ describe(REGISTRY_CONTRACT_NAME, function () {
       await expect(
         registry.connect(addr1).registerReferral(referrerId, mockProtocolId),
       )
-        .to.emit(registry, 'ReferralSkipped')
-        .withArgs(mockProtocolId, referrerId, addr1.address)
+        .to.be.revertedWithCustomError(registry, 'ReferrerNotRegistered')
+        .withArgs(mockProtocolId, referrerId)
     })
 
     it('should skip referral if the user is already registered', async function () {
@@ -164,7 +164,7 @@ describe(REGISTRY_CONTRACT_NAME, function () {
           .connect(addr1)
           .registerReferral(mockReferrerId2, mockProtocolId),
       )
-        .to.emit(registry, 'ReferralSkipped')
+        .to.be.revertedWithCustomError(registry, 'UserAlreadyRegistered')
         .withArgs(mockProtocolId, mockReferrerId2, addr1.address)
     })
   })

--- a/test/Registry.ts
+++ b/test/Registry.ts
@@ -16,7 +16,7 @@ describe(REGISTRY_CONTRACT_NAME, function () {
 
   beforeEach(async () => {
     // Get the signers
-    [owner, addr1] = await hre.ethers.getSigners()
+    ;[owner, addr1] = await hre.ethers.getSigners()
 
     // Deploy the Registry contract
     Registry = await hre.ethers.getContractFactory(REGISTRY_CONTRACT_NAME)
@@ -30,17 +30,15 @@ describe(REGISTRY_CONTRACT_NAME, function () {
       const rewardRates = [10]
 
       await expect(
-        (
-          await registry.registerReferrer(
-            referrerId,
-            protocolIds,
-            rewardRates,
-            mockRewardAddress,
-          )
-        ).to
-          .emit(registry, 'ReferrerRegistered')
-          .withArgs(referrerId, protocolIds, rewardRates, mockRewardAddress),
+        registry.registerReferrer(
+          referrerId,
+          protocolIds,
+          rewardRates,
+          mockRewardAddress,
+        ),
       )
+        .to.emit(registry, 'ReferrerRegistered')
+        .withArgs(referrerId, protocolIds, rewardRates, mockRewardAddress)
 
       // Check that the referrer was registered correctly
       const referrer = await registry.getRewardRate('protocol1', referrerId)
@@ -56,17 +54,15 @@ describe(REGISTRY_CONTRACT_NAME, function () {
 
       // Non-owner (addr1) should not be able to register the referrer
       await expect(
-        (
-          await registry
-            .connect(addr1)
-            .registerReferrer(
-              referrerId,
-              protocolIds,
-              rewardRates,
-              mockRewardAddress,
-            )
-        ).to.be.rejectedWith('AccessControlUnauthorizedAccount'),
-      )
+        registry
+          .connect(addr1)
+          .registerReferrer(
+            referrerId,
+            protocolIds,
+            rewardRates,
+            mockRewardAddress,
+          ),
+      ).to.be.rejectedWith('AccessControlUnauthorizedAccount')
     })
   })
 
@@ -84,12 +80,10 @@ describe(REGISTRY_CONTRACT_NAME, function () {
       )
 
       await expect(
-        (
-          await registry.connect(addr1).registerReferral(referrerId, protocolId)
-        ).to
-          .emit(registry, 'ReferralRegistered')
-          .withArgs(protocolId, referrerId, addr1.address),
+        registry.connect(addr1).registerReferral(referrerId, protocolId),
       )
+        .to.emit(registry, 'ReferralRegistered')
+        .withArgs(protocolId, referrerId, addr1.address)
 
       const [userAddresses, timestamps] = await registry.getUsers(
         protocolId,
@@ -104,12 +98,10 @@ describe(REGISTRY_CONTRACT_NAME, function () {
       const protocolId = 'protocol1'
 
       await expect(
-        (
-          await registry.connect(addr1).registerReferral(referrerId, protocolId)
-        ).to
-          .emit(registry, 'ReferralSkipped')
-          .withArgs(protocolId, referrerId, addr1.address),
+        registry.connect(addr1).registerReferral(referrerId, protocolId),
       )
+        .to.emit(registry, 'ReferralSkipped')
+        .withArgs(protocolId, referrerId, addr1.address)
     })
 
     it('should skip referral if the user is already registered', async function () {
@@ -127,12 +119,10 @@ describe(REGISTRY_CONTRACT_NAME, function () {
 
       // Trying to register again should emit "ReferralSkipped"
       await expect(
-        (
-          await registry.connect(addr1).registerReferral(referrerId, protocolId)
-        ).to
-          .emit(registry, 'ReferralSkipped')
-          .withArgs(protocolId, referrerId, addr1.address),
+        registry.connect(addr1).registerReferral(referrerId, protocolId),
       )
+        .to.emit(registry, 'ReferralSkipped')
+        .withArgs(protocolId, referrerId, addr1.address)
     })
   })
 

--- a/test/Registry.ts
+++ b/test/Registry.ts
@@ -154,6 +154,12 @@ describe(REGISTRY_CONTRACT_NAME, function () {
         mockRewardRates,
         mockRewardAddress,
       )
+      await registry.registerReferrer(
+        mockReferrerId2,
+        [mockProtocolId],
+        mockRewardRates,
+        mockRewardAddress,
+      )
       await registry
         .connect(addr1)
         .registerReferral(mockReferrerId, mockProtocolId)

--- a/test/Registry.ts
+++ b/test/Registry.ts
@@ -196,7 +196,7 @@ describe(REGISTRY_CONTRACT_NAME, function () {
         .connect(addr1)
         .registerReferral(mockReferrerId, mockProtocolId)
 
-      // Trying to register again should emit "ReferralSkipped"
+      // Trying to register again should revert with custom error "UserAlreadyRegistered"
       await expect(
         registry
           .connect(addr1)
@@ -222,6 +222,21 @@ describe(REGISTRY_CONTRACT_NAME, function () {
       const referrers = await registry.getReferrers(mockProtocolId)
       expect(referrers).to.deep.equal([mockReferrerId])
     })
+
+    it('should return protocols for a referrer', async function () {
+        const { registry } = await deployRegistryContract()
+        const protocolIds = [mockProtocolId]
+  
+        await registry.registerReferrer(
+          mockReferrerId,
+          protocolIds,
+          mockRewardRates,
+          mockRewardAddress,
+        )
+  
+        const protocols = await registry.getProtocols(mockReferrerId)
+        expect(protocols).to.deep.equal([mockProtocolId])
+      })
 
     it('should return users and their timestamps', async function () {
       const { registry, addr1 } = await deployRegistryContract()

--- a/test/Registry.ts
+++ b/test/Registry.ts
@@ -165,7 +165,7 @@ describe(REGISTRY_CONTRACT_NAME, function () {
           .registerReferral(mockReferrerId2, mockProtocolId),
       )
         .to.emit(registry, 'ReferralSkipped')
-        .withArgs(mockProtocolId, mockReferrerId, addr1.address)
+        .withArgs(mockProtocolId, mockReferrerId2, addr1.address)
     })
   })
 

--- a/test/Registry.ts
+++ b/test/Registry.ts
@@ -3,11 +3,10 @@ import hre from 'hardhat'
 import { getAddress } from 'ethers'
 
 const REGISTRY_CONTRACT_NAME = 'Registry'
-const REWARD_TOKEN_CONTRACT_NAME = 'MockErc20'
 
-const mockRewardTokenAddress = getAddress(
-    '0x471EcE3750Da237f93B8E339c536989b8978a499'.toLowerCase(),
-  )
+const mockRewardAddress = getAddress(
+  '0x471EcE3750Da237f93B8E339c536989b8978a499'.toLowerCase(),
+)
 
 describe(REGISTRY_CONTRACT_NAME, function () {
   let Registry
@@ -15,21 +14,14 @@ describe(REGISTRY_CONTRACT_NAME, function () {
   let owner
   let addr1
   let _addr2
-  let token
 
   beforeEach(async () => {
     // Get the signers
-    [owner, addr1, _addr2] = await hre.ethers.getSigners()
+    ;[owner, addr1, _addr2] = await hre.ethers.getSigners()
 
     // Deploy the Registry contract
     Registry = await hre.ethers.getContractFactory(REGISTRY_CONTRACT_NAME)
     registry = await Registry.deploy(owner.address, 0)
-
-    // Create a mock ERC20 token to use as reward token
-    const RewardToken = await hre.ethers.getContractFactory(
-        REWARD_TOKEN_CONTRACT_NAME,
-      )
-      const token = await RewardToken.deploy('FOO', 'BAR')
   })
 
   describe('Referrer Registration', function () {
@@ -37,14 +29,18 @@ describe(REGISTRY_CONTRACT_NAME, function () {
       const referrerId = 'referrer1'
       const protocolIds = ['protocol1']
       const rewardRates = [10]
-      const rewardAddress = token.address
 
       await expect(
         await registry
-          .registerReferrer(referrerId, protocolIds, rewardRates, rewardAddress)
+          .registerReferrer(
+            referrerId,
+            protocolIds,
+            rewardRates,
+            mockRewardAddress,
+          )
 
           .to.emit(registry, 'ReferrerRegistered')
-          .withArgs(referrerId, protocolIds, rewardRates, rewardAddress),
+          .withArgs(referrerId, protocolIds, rewardRates, mockRewardAddress),
       )
 
       // Check that the referrer was registered correctly
@@ -58,13 +54,17 @@ describe(REGISTRY_CONTRACT_NAME, function () {
       const referrerId = 'referrer1'
       const protocolIds = ['protocol1']
       const rewardRates = [10]
-      const rewardAddress = token.address
 
       // Non-owner (addr1) should not be able to register the referrer
       await expect(
         await registry
           .connect(addr1)
-          .registerReferrer(referrerId, protocolIds, rewardRates, rewardAddress)
+          .registerReferrer(
+            referrerId,
+            protocolIds,
+            rewardRates,
+            mockRewardAddress,
+          )
           .to.be.rejectedWith('AccessControlUnauthorizedAccount'),
       )
     })
@@ -74,14 +74,13 @@ describe(REGISTRY_CONTRACT_NAME, function () {
     it('should register a referral when referrer exists', async function () {
       const referrerId = 'referrer1'
       const protocolId = 'protocol1'
-      const rewardAddress = token.address
       const rewardRates = [10]
 
       await registry.registerReferrer(
         referrerId,
         [protocolId],
         rewardRates,
-        rewardAddress,
+        mockRewardAddress,
       )
 
       await expect(
@@ -116,14 +115,13 @@ describe(REGISTRY_CONTRACT_NAME, function () {
     it('should skip referral if the user is already registered', async function () {
       const referrerId = 'referrer1'
       const protocolId = 'protocol1'
-      const rewardAddress = token.address
       const rewardRates = [10]
 
       await registry.registerReferrer(
         referrerId,
         [protocolId],
         rewardRates,
-        rewardAddress,
+        mockRewardAddress,
       )
       await registry.connect(addr1).registerReferral(referrerId, protocolId)
 
@@ -143,13 +141,12 @@ describe(REGISTRY_CONTRACT_NAME, function () {
       const referrerId = 'referrer1'
       const protocolIds = ['protocol1']
       const rewardRates = [10]
-      const rewardAddress = token.address
 
       await registry.registerReferrer(
         referrerId,
         protocolIds,
         rewardRates,
-        rewardAddress,
+        mockRewardAddress,
       )
 
       const referrers = await registry.getReferrers('protocol1')
@@ -159,14 +156,13 @@ describe(REGISTRY_CONTRACT_NAME, function () {
     it('should return users and their timestamps', async function () {
       const referrerId = 'referrer1'
       const protocolId = 'protocol1'
-      const rewardAddress = token.address
       const rewardRates = [10]
 
       await registry.registerReferrer(
         referrerId,
         [protocolId],
         rewardRates,
-        rewardAddress,
+        mockRewardAddress,
       )
 
       await registry.connect(addr1).registerReferral(referrerId, protocolId)
@@ -182,14 +178,13 @@ describe(REGISTRY_CONTRACT_NAME, function () {
     it('should return the correct reward rate', async function () {
       const referrerId = 'referrer1'
       const protocolId = 'protocol1'
-      const rewardAddress = token.address
       const rewardRates = [10]
 
       await registry.registerReferrer(
         referrerId,
         [protocolId],
         rewardRates,
-        rewardAddress,
+        mockRewardAddress,
       )
 
       const rewardRate = await registry.getRewardRate(protocolId, referrerId)

--- a/test/Registry.ts
+++ b/test/Registry.ts
@@ -1,0 +1,191 @@
+import { expect } from 'chai'
+import hre from 'hardhat'
+
+const REGISTRY_CONTRACT_NAME = 'Registry'
+
+describe(REGISTRY_CONTRACT_NAME, function () {
+  let Registry
+  let registry
+  let owner
+  let addr1
+  let addr2
+  let token
+
+  beforeEach(async () => {
+    // Get the signers
+    ;[owner, addr1, addr2] = await hre.ethers.getSigners()
+
+    // Deploy the Registry contract
+    Registry = await hre.ethers.getContractFactory(REGISTRY_CONTRACT_NAME)
+    registry = await Registry.deploy(owner.address, 0)
+
+    // Create a mock ERC20 token to use as reward token
+    const ERC20 = await hre.ethers.getContractFactory('ERC20')
+    token = await ERC20.deploy('Mock Token', 'MTK', 1000000)
+  })
+
+  describe('Referrer Registration', function () {
+    it('should register a referrer correctly', async function () {
+      const referrerId = 'referrer1'
+      const protocolIds = ['protocol1']
+      const rewardRates = [10]
+      const rewardAddress = token.address
+
+      await expect(
+        await registry
+          .registerReferrer(referrerId, protocolIds, rewardRates, rewardAddress)
+
+          .to.emit(registry, 'ReferrerRegistered')
+          .withArgs(referrerId, protocolIds, rewardRates, rewardAddress),
+      )
+
+      // Check that the referrer was registered correctly
+      const referrer = await registry.getRewardRate('protocol1', referrerId)
+      expect(referrer).to.equal(10)
+
+      const referrers = await registry.getReferrers('protocol1')
+      expect(referrers).to.deep.equal([referrerId])
+    })
+    it('should allow only the owner to register a referrer', async function () {
+      const referrerId = 'referrer1'
+      const protocolIds = ['protocol1']
+      const rewardRates = [10]
+      const rewardAddress = token.address
+
+      // Non-owner (addr1) should not be able to register the referrer
+      await expect(
+        await registry
+          .connect(addr1)
+          .registerReferrer(referrerId, protocolIds, rewardRates, rewardAddress)
+          .to.be.rejectedWith('AccessControlUnauthorizedAccount'),
+      )
+    })
+  })
+
+  describe('Referral Registration', function () {
+    it('should register a referral when referrer exists', async function () {
+      const referrerId = 'referrer1'
+      const protocolId = 'protocol1'
+      const rewardAddress = token.address
+      const rewardRates = [10]
+
+      await registry.registerReferrer(
+        referrerId,
+        [protocolId],
+        rewardRates,
+        rewardAddress,
+      )
+
+      await expect(
+        await registry
+          .connect(addr1)
+          .registerReferral(referrerId, protocolId)
+          .to.emit(registry, 'ReferralRegistered')
+          .withArgs(protocolId, referrerId, addr1.address),
+      )
+
+      const [userAddresses, timestamps] = await registry.getUsers(
+        protocolId,
+        referrerId,
+      )
+      expect(userAddresses).to.include(addr1.address)
+      expect(timestamps[0]).to.be.above(0)
+    })
+
+    it('should skip referral if the referrer does not exist', async function () {
+      const referrerId = 'referrerNotExist'
+      const protocolId = 'protocol1'
+
+      await expect(
+        await registry
+          .connect(addr1)
+          .registerReferral(referrerId, protocolId)
+          .to.emit(registry, 'ReferralSkipped')
+          .withArgs(protocolId, referrerId, addr1.address),
+      )
+    })
+
+    it('should skip referral if the user is already registered', async function () {
+      const referrerId = 'referrer1'
+      const protocolId = 'protocol1'
+      const rewardAddress = token.address
+      const rewardRates = [10]
+
+      await registry.registerReferrer(
+        referrerId,
+        [protocolId],
+        rewardRates,
+        rewardAddress,
+      )
+      await registry.connect(addr1).registerReferral(referrerId, protocolId)
+
+      // Trying to register again should emit "ReferralSkipped"
+      await expect(
+        await registry
+          .connect(addr1)
+          .registerReferral(referrerId, protocolId)
+          .to.emit(registry, 'ReferralSkipped')
+          .withArgs(protocolId, referrerId, addr1.address),
+      )
+    })
+  })
+
+  describe('Getters', function () {
+    it('should return referrers for a protocol', async function () {
+      const referrerId = 'referrer1'
+      const protocolIds = ['protocol1']
+      const rewardRates = [10]
+      const rewardAddress = token.address
+
+      await registry.registerReferrer(
+        referrerId,
+        protocolIds,
+        rewardRates,
+        rewardAddress,
+      )
+
+      const referrers = await registry.getReferrers('protocol1')
+      expect(referrers).to.deep.equal([referrerId])
+    })
+
+    it('should return users and their timestamps', async function () {
+      const referrerId = 'referrer1'
+      const protocolId = 'protocol1'
+      const rewardAddress = token.address
+      const rewardRates = [10]
+
+      await registry.registerReferrer(
+        referrerId,
+        [protocolId],
+        rewardRates,
+        rewardAddress,
+      )
+
+      await registry.connect(addr1).registerReferral(referrerId, protocolId)
+      const [userAddresses, timestamps] = await registry.getUsers(
+        protocolId,
+        referrerId,
+      )
+
+      expect(userAddresses).to.include(addr1.address)
+      expect(timestamps[0]).to.be.above(0)
+    })
+
+    it('should return the correct reward rate', async function () {
+      const referrerId = 'referrer1'
+      const protocolId = 'protocol1'
+      const rewardAddress = token.address
+      const rewardRates = [10]
+
+      await registry.registerReferrer(
+        referrerId,
+        [protocolId],
+        rewardRates,
+        rewardAddress,
+      )
+
+      const rewardRate = await registry.getRewardRate(protocolId, referrerId)
+      expect(rewardRate).to.equal(10)
+    })
+  })
+})

--- a/test/Registry.ts
+++ b/test/Registry.ts
@@ -16,7 +16,7 @@ describe(REGISTRY_CONTRACT_NAME, function () {
 
   beforeEach(async () => {
     // Get the signers
-    [owner, addr1] = await hre.ethers.getSigners()
+    ;[owner, addr1] = await hre.ethers.getSigners()
 
     // Deploy the Registry contract
     Registry = await hre.ethers.getContractFactory(REGISTRY_CONTRACT_NAME)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3832,6 +3832,19 @@ ethereumjs-util@^7.0.3, ethereumjs-util@^7.1.4, ethereumjs-util@^7.1.5:
     ethereum-cryptography "^0.1.3"
     rlp "^2.2.4"
 
+ethers@^6.13.5:
+  version "6.13.5"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.13.5.tgz#8c1d6ac988ac08abc3c1d8fabbd4b8b602851ac4"
+  integrity sha512-+knKNieu5EKRThQJWwqaJ10a6HE9sSehGeqWN65//wE7j47ZpFhKAnHB/JJFibwwg61I/koxaPsXbXpD/skNOQ==
+  dependencies:
+    "@adraffy/ens-normalize" "1.10.1"
+    "@noble/curves" "1.2.0"
+    "@noble/hashes" "1.3.2"
+    "@types/node" "22.7.5"
+    aes-js "4.0.0-beta.5"
+    tslib "2.7.0"
+    ws "8.17.1"
+
 ethers@^6.7.0:
   version "6.13.4"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.13.4.tgz#bd3e1c3dc1e7dc8ce10f9ffb4ee40967a651b53c"


### PR DESCRIPTION
Registry contract created with:

Write methods:
- `registerReferrer` (owner only)
- `registerReferral`

Read methods:
- `getReferrers` for a given protocol
- `getUsers` for a given protocol, referrer pair
- `getRewardRate` for a given protocol, referrer pair

`npx hardhat compile` to create the ABI (I cleaned up output to what it is now)

Unit tests added