### PR TITLE
feat(revenue): Add initial skeleton revenue script

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,16 @@ module.exports = {
     'plugin:import/recommended',
     'plugin:import/typescript',
   ],
+  rules: {
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+      },
+    ],
+  },
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint', 'import'],
   settings: {

--- a/scripts/calculateRevenue/calculateRevenue.ts
+++ b/scripts/calculateRevenue/calculateRevenue.ts
@@ -17,11 +17,11 @@ async function main(args: ReturnType<typeof parseArgs>) {
     console.log(
       `Calculating revenue for ${address} (${i + 1}/${eligibleAddresses.length})`,
     )
-    const userResult = await handler(
+    const userResult = await handler({
       address,
-      new Date(args['start-timestamp']),
-      new Date(args['end-timestamp']),
-    )
+      startTimestamp: new Date(args['start-timestamp']),
+      endTimestamp: new Date(args['end-timestamp']),
+    })
     allResults[address] = userResult
   }
 

--- a/scripts/calculateRevenue/calculateRevenue.ts
+++ b/scripts/calculateRevenue/calculateRevenue.ts
@@ -1,0 +1,79 @@
+import calculateRevenueHandlers from './protocols'
+import { readFileSync, writeFileSync } from 'fs'
+import yargs from 'yargs'
+import { protocols, Protocol, RevenueResult } from '../types'
+
+async function main(args: ReturnType<typeof parseArgs>) {
+  const eligibleAddresses = readFileSync(args['input-addresses'], 'utf-8')
+    .split('\n')
+    .filter((address) => address !== '')
+
+  const handler = calculateRevenueHandlers[args['protocol-id'] as Protocol]
+
+  const allResults: Record<string, RevenueResult> = {}
+
+  for (let i = 0; i < eligibleAddresses.length; i++) {
+    const address = eligibleAddresses[i]
+    console.log(
+      `Calculating revenue for ${address} (${i + 1}/${eligibleAddresses.length})`,
+    )
+    const userResult = await handler(
+      address,
+      new Date(args['start-timestamp']),
+      new Date(args['end-timestamp']),
+    )
+    allResults[address] = userResult
+  }
+
+  writeFileSync(args['output-file'], JSON.stringify(allResults, null, 4))
+  console.log(`Wrote results to ${args['output-file']}`)
+}
+
+function parseArgs() {
+  return yargs
+    .option('input-addresses', {
+      alias: 'i',
+      description: 'input file path of user addresses, newline separated',
+      type: 'string',
+      demandOption: true,
+    })
+    .option('output-file', {
+      alias: 'o',
+      description: 'output file path to write JSON results',
+      type: 'string',
+      demandOption: true,
+    })
+    .option('protocol-id', {
+      alias: 'p',
+      description: 'ID of protocol to check against',
+      choices: protocols,
+      demandOption: true,
+    })
+    .option('start-timestamp', {
+      alias: 's',
+      description:
+        'timestamp at which to start checking for revenue (since epoch)',
+      type: 'number',
+      demandOption: true,
+    })
+    .option('end-timestamp', {
+      alias: 'e',
+      description:
+        'timestamp at which to stop checking for revenue (since epoch)',
+      type: 'number',
+      demandOption: true,
+    })
+    .strict()
+    .parseSync()
+}
+
+if (require.main === module) {
+  main(parseArgs())
+    .then(() => {
+      process.exit(0)
+    })
+    .catch((err) => {
+      console.log(err)
+      process.exit(1)
+    })
+}

--- a/scripts/calculateRevenue/protocols/beefy.ts
+++ b/scripts/calculateRevenue/protocols/beefy.ts
@@ -1,0 +1,9 @@
+import { RevenueResult } from '../../types'
+
+export async function calculateRevenue(
+  _address: string,
+  _startTimestamp: Date,
+  _endTimestamp: Date,
+): Promise<RevenueResult> {
+  return {}
+}

--- a/scripts/calculateRevenue/protocols/beefy.ts
+++ b/scripts/calculateRevenue/protocols/beefy.ts
@@ -1,9 +1,9 @@
 import { RevenueResult } from '../../types'
 
-export async function calculateRevenue(
-  _address: string,
-  _startTimestamp: Date,
-  _endTimestamp: Date,
-): Promise<RevenueResult> {
+export async function calculateRevenue(_params: {
+  address: string
+  startTimestamp: Date
+  endTimestamp: Date
+}): Promise<RevenueResult> {
   return {}
 }

--- a/scripts/calculateRevenue/protocols/index.ts
+++ b/scripts/calculateRevenue/protocols/index.ts
@@ -1,0 +1,8 @@
+import { Protocol, CalculateRevenueFn } from '../../types'
+import { calculateRevenue as calculateRevenueBeefy } from './beefy'
+
+const calculateRevenueHandlers: Record<Protocol, CalculateRevenueFn> = {
+  Beefy: calculateRevenueBeefy,
+}
+
+export default calculateRevenueHandlers

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -1,3 +1,33 @@
+export const protocols = ['Beefy'] as const
+export type Protocol = (typeof protocols)[number]
+
+export enum NetworkId {
+  'celo-mainnet' = 'celo-mainnet',
+  'celo-alfajores' = 'celo-alfajores',
+  'ethereum-mainnet' = 'ethereum-mainnet',
+  'ethereum-sepolia' = 'ethereum-sepolia',
+  'arbitrum-one' = 'arbitrum-one',
+  'arbitrum-sepolia' = 'arbitrum-sepolia',
+  'op-mainnet' = 'op-mainnet',
+  'op-sepolia' = 'op-sepolia',
+  'polygon-pos-mainnet' = 'polygon-pos-mainnet',
+  'polygon-pos-amoy' = 'polygon-pos-amoy',
+  'base-mainnet' = 'base-mainnet',
+  'base-sepolia' = 'base-sepolia',
+}
+
+// Protocols may generate revenue in different denominations,
+// this is a map from tokenIds to revenue generated for a
+// protocol, denominated in units of the token; these maps
+// are organized by NetworkId
+export type RevenueResult = Partial<Record<NetworkId, Record<string, string>>>
+
+export type CalculateRevenueFn = (
+  address: string,
+  startTimestamp: Date,
+  endTimestamp: Date,
+) => Promise<RevenueResult>
+
 export interface ReferralEvent {
   userAddress: string
   timestamp: number

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -22,11 +22,11 @@ export enum NetworkId {
 // are organized by NetworkId
 export type RevenueResult = Partial<Record<NetworkId, Record<string, string>>>
 
-export type CalculateRevenueFn = (
-  address: string,
-  startTimestamp: Date,
-  endTimestamp: Date,
-) => Promise<RevenueResult>
+export type CalculateRevenueFn = (params: {
+  address: string
+  startTimestamp: Date
+  endTimestamp: Date
+}) => Promise<RevenueResult>
 
 export interface ReferralEvent {
   userAddress: string


### PR DESCRIPTION
This is the first PR in a chain to get an initial version of the Beefy revenue attribution script working. See this [closed PR](https://github.com/mobilestack-xyz/funding-layer/pull/6#issue-2778995969) for a description/high-level overview of what this will eventually look like; I closed that PR in favor of a series of smaller PRs. I recommend reading the overview linked above to get a sense of what exactly these PRs are working towards.

This PR introduces a skeleton framework for writing handlers for calculating revenue attribution for different protocols.