### PR TITLE
feat(revenue): Add Beefy helper to fetch vault TVL

### DIFF
--- a/scripts/calculateRevenue/protocols/beefy.test.ts
+++ b/scripts/calculateRevenue/protocols/beefy.test.ts
@@ -9,9 +9,11 @@ describe('Beefy revenue calculation', () => {
         ['bar', 2],
       ] as BeefyVaultTvlData[]
       nock(`https://databarn.beefy.com`)
-        .get(
-          `/api/v1/beefy/product/celo/0x123/tvl?from_date_utc=2025-01-10T16:14:52.000Z&to_date_utc=2025-01-13T16:14:52.000Z`,
-        )
+        .get(`/api/v1/beefy/product/celo/0x123/tvl`)
+        .query({
+          from_date_utc: '2025-01-10T16:14:52.000Z',
+          to_date_utc: '2025-01-13T16:14:52.000Z',
+        })
         .reply(200, mockVaultTvlData)
 
       const vaultAddress = '0x123'
@@ -19,12 +21,12 @@ describe('Beefy revenue calculation', () => {
       const startTimestamp = new Date('2025-01-10T16:14:52+00:00')
       const endTimestamp = new Date('2025-01-13T16:14:52+00:00')
 
-      const result = await fetchVaultTvlHistory(
+      const result = await fetchVaultTvlHistory({
         vaultAddress,
         beefyChain,
         startTimestamp,
         endTimestamp,
-      )
+      })
       expect(result).toEqual(mockVaultTvlData)
     })
     it('should return correct results for an exactly 1 week span', async () => {
@@ -33,9 +35,11 @@ describe('Beefy revenue calculation', () => {
         ['bar', 2],
       ] as BeefyVaultTvlData[]
       nock(`https://databarn.beefy.com`)
-        .get(
-          `/api/v1/beefy/product/celo/0x123/tvl?from_date_utc=2025-01-10T16:14:52.000Z&to_date_utc=2025-01-17T16:14:52.000Z`,
-        )
+        .get(`/api/v1/beefy/product/celo/0x123/tvl`)
+        .query({
+          from_date_utc: '2025-01-10T16:14:52.000Z',
+          to_date_utc: '2025-01-17T16:14:52.000Z',
+        })
         .reply(200, mockVaultTvlData)
 
       const vaultAddress = '0x123'
@@ -43,12 +47,12 @@ describe('Beefy revenue calculation', () => {
       const startTimestamp = new Date('2025-01-10T16:14:52+00:00')
       const endTimestamp = new Date('2025-01-17T16:14:52+00:00')
 
-      const result = await fetchVaultTvlHistory(
+      const result = await fetchVaultTvlHistory({
         vaultAddress,
         beefyChain,
         startTimestamp,
         endTimestamp,
-      )
+      })
       expect(result).toEqual(mockVaultTvlData)
     })
     it('should return correct results for a >1 week span', async () => {
@@ -69,14 +73,18 @@ describe('Beefy revenue calculation', () => {
       ] as BeefyVaultTvlData[]
 
       nock(`https://databarn.beefy.com`)
-        .get(
-          `/api/v1/beefy/product/celo/0x123/tvl?from_date_utc=2025-01-10T16:14:52.000Z&to_date_utc=2025-01-17T16:14:52.000Z`,
-        )
+        .get(`/api/v1/beefy/product/celo/0x123/tvl`)
+        .query({
+          from_date_utc: '2025-01-10T16:14:52.000Z',
+          to_date_utc: '2025-01-17T16:14:52.000Z',
+        })
         .reply(200, mockVaultTvlWeekOneData)
       nock(`https://databarn.beefy.com`)
-        .get(
-          `/api/v1/beefy/product/celo/0x123/tvl?from_date_utc=2025-01-17T16:14:52.000Z&to_date_utc=2025-01-20T16:14:52.000Z`,
-        )
+        .get(`/api/v1/beefy/product/celo/0x123/tvl`)
+        .query({
+          from_date_utc: '2025-01-17T16:14:52.000Z',
+          to_date_utc: '2025-01-20T16:14:52.000Z',
+        })
         .reply(200, mockVaultTvlWeekTwoData)
 
       const vaultAddress = '0x123'
@@ -84,12 +92,12 @@ describe('Beefy revenue calculation', () => {
       const startTimestamp = new Date('2025-01-10T16:14:52+00:00')
       const endTimestamp = new Date('2025-01-20T16:14:52+00:00')
 
-      const result = await fetchVaultTvlHistory(
+      const result = await fetchVaultTvlHistory({
         vaultAddress,
         beefyChain,
         startTimestamp,
         endTimestamp,
-      )
+      })
       expect(result).toEqual(mockVaultTvlData)
     })
   })

--- a/scripts/calculateRevenue/protocols/beefy.test.ts
+++ b/scripts/calculateRevenue/protocols/beefy.test.ts
@@ -1,0 +1,96 @@
+import { fetchVaultTvlHistory, BeefyVaultTvlData } from './beefy'
+import nock from 'nock'
+
+describe('Beefy revenue calculation', () => {
+  describe('fetchVaultTvlHistory', () => {
+    it('should return correct results for a <1 week span', async () => {
+      const mockVaultTvlData = [
+        ['foo', 1],
+        ['bar', 2],
+      ] as BeefyVaultTvlData[]
+      nock(`https://databarn.beefy.com`)
+        .get(
+          `/api/v1/beefy/product/celo/0x123/tvl?from_date_utc=2025-01-10T16:14:52.000Z&to_date_utc=2025-01-13T16:14:52.000Z`,
+        )
+        .reply(200, mockVaultTvlData)
+
+      const vaultAddress = '0x123'
+      const beefyChain = 'celo'
+      const startTimestamp = new Date('2025-01-10T16:14:52+00:00')
+      const endTimestamp = new Date('2025-01-13T16:14:52+00:00')
+
+      const result = await fetchVaultTvlHistory(
+        vaultAddress,
+        beefyChain,
+        startTimestamp,
+        endTimestamp,
+      )
+      expect(result).toEqual(mockVaultTvlData)
+    })
+    it('should return correct results for an exactly 1 week span', async () => {
+      const mockVaultTvlData = [
+        ['foo', 1],
+        ['bar', 2],
+      ] as BeefyVaultTvlData[]
+      nock(`https://databarn.beefy.com`)
+        .get(
+          `/api/v1/beefy/product/celo/0x123/tvl?from_date_utc=2025-01-10T16:14:52.000Z&to_date_utc=2025-01-17T16:14:52.000Z`,
+        )
+        .reply(200, mockVaultTvlData)
+
+      const vaultAddress = '0x123'
+      const beefyChain = 'celo'
+      const startTimestamp = new Date('2025-01-10T16:14:52+00:00')
+      const endTimestamp = new Date('2025-01-17T16:14:52+00:00')
+
+      const result = await fetchVaultTvlHistory(
+        vaultAddress,
+        beefyChain,
+        startTimestamp,
+        endTimestamp,
+      )
+      expect(result).toEqual(mockVaultTvlData)
+    })
+    it('should return correct results for a >1 week span', async () => {
+      const mockVaultTvlWeekOneData = [
+        ['foo', 1],
+        ['bar', 2],
+      ] as BeefyVaultTvlData[]
+      const mockVaultTvlWeekTwoData = [
+        ['baz', 3],
+        ['bat', 4],
+      ] as BeefyVaultTvlData[]
+
+      const mockVaultTvlData = [
+        ['foo', 1],
+        ['bar', 2],
+        ['baz', 3],
+        ['bat', 4],
+      ] as BeefyVaultTvlData[]
+
+      nock(`https://databarn.beefy.com`)
+        .get(
+          `/api/v1/beefy/product/celo/0x123/tvl?from_date_utc=2025-01-10T16:14:52.000Z&to_date_utc=2025-01-17T16:14:52.000Z`,
+        )
+        .reply(200, mockVaultTvlWeekOneData)
+      nock(`https://databarn.beefy.com`)
+        .get(
+          `/api/v1/beefy/product/celo/0x123/tvl?from_date_utc=2025-01-17T16:14:52.000Z&to_date_utc=2025-01-20T16:14:52.000Z`,
+        )
+        .reply(200, mockVaultTvlWeekTwoData)
+
+      const vaultAddress = '0x123'
+      const beefyChain = 'celo'
+      const startTimestamp = new Date('2025-01-10T16:14:52+00:00')
+      const endTimestamp = new Date('2025-01-20T16:14:52+00:00')
+
+      const result = await fetchVaultTvlHistory(
+        vaultAddress,
+        beefyChain,
+        startTimestamp,
+        endTimestamp,
+      )
+      expect(result).toEqual(mockVaultTvlData)
+    })
+  })
+})

--- a/scripts/calculateRevenue/protocols/beefy.ts
+++ b/scripts/calculateRevenue/protocols/beefy.ts
@@ -1,4 +1,57 @@
 import { RevenueResult } from '../../types'
+import { fetchWithTimeout } from '../../utils/fetchWithTimeout'
+
+export type BeefyVaultTvlData = [string, number]
+
+const BEEFY_API_URL = 'https://databarn.beefy.com/api/v1/beefy'
+const ONE_WEEK = 7 * 24 * 60 * 60 * 1000
+
+// TODO: Memoize this function so it's not repeated for every user address
+/**
+ * For a given vault and date range, fetches historical time-series information about the TVL of the vault.
+ * The TVL data consists of 15-minute snapshots.
+ */
+export async function fetchVaultTvlHistory(
+  vaultAddress: string,
+  beefyChain: string,
+  startTimestamp: Date,
+  endTimestamp: Date,
+): Promise<BeefyVaultTvlData[]> {
+  // This endpoint accepts a maximum of one-week long spans.
+  // We need to break down the provided date range into week-long durations.
+  const timestamps = []
+  let startSectionTimestamp = startTimestamp
+  while (startSectionTimestamp < endTimestamp) {
+    const startPlusOneWeekTimestamp = new Date(
+      startSectionTimestamp.getTime() + ONE_WEEK,
+    )
+    const endSectionTimestamp =
+      startPlusOneWeekTimestamp < endTimestamp
+        ? startPlusOneWeekTimestamp
+        : endTimestamp
+    timestamps.push([startSectionTimestamp, endSectionTimestamp])
+    startSectionTimestamp = endSectionTimestamp
+  }
+
+  const data = []
+  for (const [t1, t2] of timestamps) {
+    const queryParams = new URLSearchParams({
+      from_date_utc: t1.toISOString(),
+      to_date_utc: t2.toISOString(),
+    })
+    const response = await fetchWithTimeout(
+      `${BEEFY_API_URL}/product/${beefyChain}/${vaultAddress}/tvl?${queryParams}`,
+    )
+    if (!response.ok) {
+      throw new Error(
+        `Error while fetching vault TVL data from Beefy: ${response}`,
+      )
+    }
+    const vaultTvlData = (await response.json()) as BeefyVaultTvlData[]
+    data.push(...vaultTvlData)
+  }
+  return data
+}
 
 export async function calculateRevenue(
   _address: string,

--- a/scripts/calculateRevenue/protocols/beefy.ts
+++ b/scripts/calculateRevenue/protocols/beefy.ts
@@ -11,12 +11,17 @@ const ONE_WEEK = 7 * 24 * 60 * 60 * 1000
  * For a given vault and date range, fetches historical time-series information about the TVL of the vault.
  * The TVL data consists of 15-minute snapshots.
  */
-export async function fetchVaultTvlHistory(
-  vaultAddress: string,
-  beefyChain: string,
-  startTimestamp: Date,
-  endTimestamp: Date,
-): Promise<BeefyVaultTvlData[]> {
+export async function fetchVaultTvlHistory({
+  vaultAddress,
+  beefyChain,
+  startTimestamp,
+  endTimestamp,
+}: {
+  vaultAddress: string
+  beefyChain: string
+  startTimestamp: Date
+  endTimestamp: Date
+}): Promise<BeefyVaultTvlData[]> {
   // This endpoint accepts a maximum of one-week long spans.
   // We need to break down the provided date range into week-long durations.
   const timestamps = []

--- a/scripts/utils/fetchWithTimeout.ts
+++ b/scripts/utils/fetchWithTimeout.ts
@@ -1,0 +1,20 @@
+import fetch, { RequestInit, Response } from 'node-fetch'
+
+const FETCH_TIMEOUT_DURATION = 15000 // 15 seconds
+
+export const fetchWithTimeout = async (
+  url: string,
+  options: RequestInit | null = null,
+  duration: number = FETCH_TIMEOUT_DURATION,
+): Promise<Response> => {
+  const controller = new AbortController()
+  const id = setTimeout(() => {
+    controller.abort()
+  }, duration)
+  const response = await fetch(url, {
+    ...options,
+    signal: controller.signal as NonNullable<RequestInit['signal']>,
+  })
+  clearTimeout(id)
+  return response
+}


### PR DESCRIPTION
Follow-up PR to #7. This PR introduces a helper function that calls a public [Beefy API endpoint](https://databarn.beefy.com/api/v1/documentation/static/index.html) in order to get historical vault TVL (in USD) in 15-minute increments. This will be used later on when calculating a user's share of a vault at any given time, as the denominator in the ratio.