### PR TITLE
feat(referral): fetch referrals from registry contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ yarn test
 
 ## Scripts
 
-### Filter Referrals
+### Fetch Referrals
 
-Filter out referalls where the user had already interacted with the protocol in question.
+Fetch referrals for a specific protocol, removes duplicate events across chains, and filters out events where the user was previously exposed to the protocol
 
 ```bash
-npx ts-node ./scripts/filter-referrals.ts --protocol beefy --input input.csv --output output.csv
+npx ts-node ./scripts/fetch-referrals.ts --protocol Beefy --output output.csv
 ```
 
 ## Contracts

--- a/scripts/fetch-referrals.ts
+++ b/scripts/fetch-referrals.ts
@@ -28,7 +28,6 @@ async function getArgs() {
   return {
     protocol: argv['protocol'] as Protocol,
     protocolFilter: protocolFilters[argv['protocol'] as Protocol],
-    input: argv['input'],
     output: argv['output'],
   }
 }
@@ -50,7 +49,7 @@ async function main() {
 
   const filteredEvents = await args.protocolFilter(uniqueEvents)
   const output = filteredEvents
-    .map((event) => `${event.userAddress},${event.timestamp}`)
+    .map((event) => `${args.protocol},${event.referrerId},${event.userAddress},${event.timestamp}`)
     .join('\n')
   writeFileSync(args.output, output)
 }

--- a/scripts/fetch-referrals.ts
+++ b/scripts/fetch-referrals.ts
@@ -1,16 +1,15 @@
 import yargs from 'yargs'
 import { filterEvents as beefy } from './protocol-filters/beefy'
-import { readFileSync, writeFileSync } from 'fs'
-import { ReferralEvent } from './types'
-
-const protocols = ['beefy'] as const
-type Protocol = (typeof protocols)[number]
+import { writeFileSync } from 'fs'
+import { NetworkId, Protocol, protocols, ReferralEvent } from './types'
+import { fetchReferralEvents, removeDuplicates } from './referrals'
 
 type FilterFunction = (events: ReferralEvent[]) => Promise<ReferralEvent[]>
 
 const protocolFilters: Record<Protocol, FilterFunction> = {
-  beefy,
+  Beefy: beefy,
 }
+
 async function getArgs() {
   const argv = await yargs
     .env('')
@@ -19,17 +18,11 @@ async function getArgs() {
       demandOption: true,
       choices: protocols,
     })
-    .option('input', {
-      alias: 'i',
-      description: 'input file',
-      type: 'string',
-      demandOption: true,
-    })
     .option('output', {
       alias: 'o',
       description: 'output file',
       type: 'string',
-      default: 'rewards_processed.csv',
+      default: 'filtered_referrals.csv',
     }).argv
 
   return {
@@ -43,16 +36,19 @@ async function getArgs() {
 async function main() {
   const args = await getArgs()
 
-  const referralEvents: ReferralEvent[] = readFileSync(args.input, 'utf8')
-    .split('\n')
-    .map((line) => {
-      const [userAddress, timestamp] = line.split(',')
-      return {
-        userAddress,
-        timestamp: parseInt(timestamp),
-      }
-    })
-  const filteredEvents = await args.protocolFilter(referralEvents)
+  const networkIds = [
+    NetworkId['celo-mainnet'],
+    NetworkId['ethereum-mainnet'],
+    NetworkId['arbitrum-one'],
+    NetworkId['op-mainnet'],
+    NetworkId['polygon-pos-mainnet'],
+    NetworkId['base-mainnet'],
+  ]
+
+  const referralEvents = await fetchReferralEvents(networkIds, args.protocol)
+  const uniqueEvents = removeDuplicates(referralEvents)
+
+  const filteredEvents = await args.protocolFilter(uniqueEvents)
   const output = filteredEvents
     .map((event) => `${event.userAddress},${event.timestamp}`)
     .join('\n')

--- a/scripts/fetch-referrals.ts
+++ b/scripts/fetch-referrals.ts
@@ -49,7 +49,10 @@ async function main() {
 
   const filteredEvents = await args.protocolFilter(uniqueEvents)
   const output = filteredEvents
-    .map((event) => `${args.protocol},${event.referrerId},${event.userAddress},${event.timestamp}`)
+    .map(
+      (event) =>
+        `${args.protocol},${event.referrerId},${event.userAddress},${event.timestamp}`,
+    )
     .join('\n')
   writeFileSync(args.output, output)
 }

--- a/scripts/protocol-filters/beefy.test.ts
+++ b/scripts/protocol-filters/beefy.test.ts
@@ -16,6 +16,8 @@ describe('Beefy filter function', () => {
     const event: ReferralEvent = {
       userAddress: address,
       timestamp: new Date('2023-09-30T00:00:00Z').getTime(),
+      protocol: 'Beefy',
+      referrerId: 'referrer1',
     }
 
     const result = await filter(event)
@@ -32,6 +34,8 @@ describe('Beefy filter function', () => {
     const event: ReferralEvent = {
       userAddress: address,
       timestamp: new Date('2023-09-30T00:00:00Z').getTime(),
+      protocol: 'Beefy',
+      referrerId: 'referrer1',
     }
 
     const result = await filter(event)
@@ -52,6 +56,8 @@ describe('Beefy filter function', () => {
     const event: ReferralEvent = {
       userAddress: address,
       timestamp: new Date('2023-09-30T00:00:00Z').getTime(),
+      protocol: 'Beefy',
+      referrerId: 'referrer1',
     }
 
     const result = await filter(event)

--- a/scripts/referrals.test.ts
+++ b/scripts/referrals.test.ts
@@ -1,5 +1,5 @@
 import { fetchReferralEvents, removeDuplicates } from './referrals'
-import { NetworkId } from './types'
+import { NetworkId, ReferralEvent } from './types'
 import { getRegistryContract } from './utils'
 jest.mock('./utils')
 
@@ -72,12 +72,12 @@ describe('fetchReferralEvents', () => {
       'Beefy',
     )
     expect(events).toEqual([
-      { userAddress: 'user1', timestamp: 1 },
-      { userAddress: 'user2', timestamp: 2 },
-      { userAddress: 'user3', timestamp: 3 },
-      { userAddress: 'user4', timestamp: 4 },
-      { userAddress: 'user5', timestamp: 5 },
-      { userAddress: 'user6', timestamp: 6 },
+      { userAddress: 'user1', timestamp: 1, referrerId: 'referrer1', protocol: 'Beefy' },
+      { userAddress: 'user2', timestamp: 2, referrerId: 'referrer1', protocol: 'Beefy' },
+      { userAddress: 'user3', timestamp: 3, referrerId: 'referrer2', protocol: 'Beefy' },
+      { userAddress: 'user4', timestamp: 4, referrerId: 'referrer2', protocol: 'Beefy' },
+      { userAddress: 'user5', timestamp: 5, referrerId: 'referrer1', protocol: 'Beefy' },
+      { userAddress: 'user6', timestamp: 6, referrerId: 'referrer1', protocol: 'Beefy' },
     ])
     expect(mockGetRegistryContract).toHaveBeenCalledTimes(2)
     expect(mockGetRegistryContract).toHaveBeenCalledWith(
@@ -107,14 +107,14 @@ describe('fetchReferralEvents', () => {
 describe('removeDuplicates', () => {
   it('should remove duplicate events', () => {
     const events = [
-      { userAddress: 'user1', timestamp: 1 },
-      { userAddress: 'user2', timestamp: 2 },
-      { userAddress: 'user1', timestamp: 3 },
-    ]
+      { userAddress: 'user1', timestamp: 1, referrerId: 'referrer1', protocol: 'Beefy' },
+      { userAddress: 'user2', timestamp: 2, referrerId: 'referrer1', protocol: 'Beefy' },
+      { userAddress: 'user1', timestamp: 3, referrerId: 'referrer2', protocol: 'Beefy' },
+    ] as ReferralEvent[]
     const uniqueEvents = removeDuplicates(events)
     expect(uniqueEvents).toEqual([
-      { userAddress: 'user1', timestamp: 1 },
-      { userAddress: 'user2', timestamp: 2 },
+      { userAddress: 'user1', timestamp: 1, referrerId: 'referrer1', protocol: 'Beefy' },
+      { userAddress: 'user2', timestamp: 2, referrerId: 'referrer1', protocol: 'Beefy' },
     ])
   })
 })

--- a/scripts/referrals.test.ts
+++ b/scripts/referrals.test.ts
@@ -1,0 +1,120 @@
+import { fetchReferralEvents, removeDuplicates } from './referrals'
+import { NetworkId } from './types'
+import { getRegistryContract } from './utils'
+jest.mock('./utils')
+
+describe('fetchReferralEvents', () => {
+  it('should fetch all referral events', async () => {
+    const mockGetUsersCelo = jest
+      .fn()
+      .mockImplementation(([_, referrer]: [string, string]) => {
+        if (referrer === 'referrer1') {
+          return [
+            ['user1', 'user2'],
+            [1, 2],
+          ]
+        }
+        if (referrer === 'referrer2') {
+          return [
+            ['user3', 'user4'],
+            [3, 4],
+          ]
+        }
+      })
+    const mockGetReferrersCelo = jest
+      .fn()
+      .mockImplementation(([protocol]: [string]) => {
+        if (protocol === 'Beefy') {
+          return ['referrer1', 'referrer2']
+        }
+      })
+    const mockGetUsersArbitrum = jest
+      .fn()
+      .mockImplementation(([_, referrer]: [string, string]) => {
+        if (referrer === 'referrer1') {
+          return [
+            ['user5', 'user6'],
+            [5, 6],
+          ]
+        }
+      })
+    const mockGetReferrersArbitrum = jest
+      .fn()
+      .mockImplementation(([protocol]: [string]) => {
+        if (protocol === 'Beefy') {
+          return ['referrer1']
+        }
+      })
+
+    const mockGetRegistryContract = jest
+      .fn()
+      .mockImplementation(async (_, networkId: NetworkId) => {
+        if (networkId === NetworkId['celo-mainnet']) {
+          return {
+            read: {
+              getUsers: mockGetUsersCelo,
+              getReferrers: mockGetReferrersCelo,
+            },
+          }
+        } else {
+          return {
+            read: {
+              getUsers: mockGetUsersArbitrum,
+              getReferrers: mockGetReferrersArbitrum,
+            },
+          }
+        }
+      })
+    jest.mocked(getRegistryContract).mockImplementation(mockGetRegistryContract)
+
+    const events = await fetchReferralEvents(
+      [NetworkId['celo-mainnet'], NetworkId['arbitrum-one']],
+      'Beefy',
+    )
+    expect(events).toEqual([
+      { userAddress: 'user1', timestamp: 1 },
+      { userAddress: 'user2', timestamp: 2 },
+      { userAddress: 'user3', timestamp: 3 },
+      { userAddress: 'user4', timestamp: 4 },
+      { userAddress: 'user5', timestamp: 5 },
+      { userAddress: 'user6', timestamp: 6 },
+    ])
+    expect(mockGetRegistryContract).toHaveBeenCalledTimes(2)
+    expect(mockGetRegistryContract).toHaveBeenCalledWith(
+      '0x0',
+      NetworkId['celo-mainnet'],
+    )
+    expect(mockGetRegistryContract).toHaveBeenCalledWith(
+      '0x0',
+      NetworkId['arbitrum-one'],
+    )
+
+    expect(mockGetReferrersArbitrum).toHaveBeenCalledTimes(1)
+    expect(mockGetReferrersArbitrum).toHaveBeenCalledWith(['Beefy'])
+
+    expect(mockGetReferrersCelo).toHaveBeenCalledTimes(1)
+    expect(mockGetReferrersCelo).toHaveBeenCalledWith(['Beefy'])
+
+    expect(mockGetUsersArbitrum).toHaveBeenCalledTimes(1)
+    expect(mockGetUsersArbitrum).toHaveBeenCalledWith(['Beefy', 'referrer1'])
+
+    expect(mockGetUsersCelo).toHaveBeenCalledTimes(2)
+    expect(mockGetUsersCelo).toHaveBeenCalledWith(['Beefy', 'referrer1'])
+    expect(mockGetUsersCelo).toHaveBeenCalledWith(['Beefy', 'referrer2'])
+  })
+})
+
+describe('removeDuplicates', () => {
+  it('should remove duplicate events', () => {
+    const events = [
+      { userAddress: 'user1', timestamp: 1 },
+      { userAddress: 'user2', timestamp: 2 },
+      { userAddress: 'user1', timestamp: 3 },
+    ]
+    const uniqueEvents = removeDuplicates(events)
+    expect(uniqueEvents).toEqual([
+      { userAddress: 'user1', timestamp: 1 },
+      { userAddress: 'user2', timestamp: 2 },
+    ])
+  })
+})

--- a/scripts/referrals.test.ts
+++ b/scripts/referrals.test.ts
@@ -72,12 +72,42 @@ describe('fetchReferralEvents', () => {
       'Beefy',
     )
     expect(events).toEqual([
-      { userAddress: 'user1', timestamp: 1, referrerId: 'referrer1', protocol: 'Beefy' },
-      { userAddress: 'user2', timestamp: 2, referrerId: 'referrer1', protocol: 'Beefy' },
-      { userAddress: 'user3', timestamp: 3, referrerId: 'referrer2', protocol: 'Beefy' },
-      { userAddress: 'user4', timestamp: 4, referrerId: 'referrer2', protocol: 'Beefy' },
-      { userAddress: 'user5', timestamp: 5, referrerId: 'referrer1', protocol: 'Beefy' },
-      { userAddress: 'user6', timestamp: 6, referrerId: 'referrer1', protocol: 'Beefy' },
+      {
+        userAddress: 'user1',
+        timestamp: 1,
+        referrerId: 'referrer1',
+        protocol: 'Beefy',
+      },
+      {
+        userAddress: 'user2',
+        timestamp: 2,
+        referrerId: 'referrer1',
+        protocol: 'Beefy',
+      },
+      {
+        userAddress: 'user3',
+        timestamp: 3,
+        referrerId: 'referrer2',
+        protocol: 'Beefy',
+      },
+      {
+        userAddress: 'user4',
+        timestamp: 4,
+        referrerId: 'referrer2',
+        protocol: 'Beefy',
+      },
+      {
+        userAddress: 'user5',
+        timestamp: 5,
+        referrerId: 'referrer1',
+        protocol: 'Beefy',
+      },
+      {
+        userAddress: 'user6',
+        timestamp: 6,
+        referrerId: 'referrer1',
+        protocol: 'Beefy',
+      },
     ])
     expect(mockGetRegistryContract).toHaveBeenCalledTimes(2)
     expect(mockGetRegistryContract).toHaveBeenCalledWith(
@@ -107,14 +137,39 @@ describe('fetchReferralEvents', () => {
 describe('removeDuplicates', () => {
   it('should remove duplicate events', () => {
     const events = [
-      { userAddress: 'user1', timestamp: 1, referrerId: 'referrer1', protocol: 'Beefy' },
-      { userAddress: 'user2', timestamp: 2, referrerId: 'referrer1', protocol: 'Beefy' },
-      { userAddress: 'user1', timestamp: 3, referrerId: 'referrer2', protocol: 'Beefy' },
+      {
+        userAddress: 'user1',
+        timestamp: 1,
+        referrerId: 'referrer1',
+        protocol: 'Beefy',
+      },
+      {
+        userAddress: 'user2',
+        timestamp: 2,
+        referrerId: 'referrer1',
+        protocol: 'Beefy',
+      },
+      {
+        userAddress: 'user1',
+        timestamp: 3,
+        referrerId: 'referrer2',
+        protocol: 'Beefy',
+      },
     ] as ReferralEvent[]
     const uniqueEvents = removeDuplicates(events)
     expect(uniqueEvents).toEqual([
-      { userAddress: 'user1', timestamp: 1, referrerId: 'referrer1', protocol: 'Beefy' },
-      { userAddress: 'user2', timestamp: 2, referrerId: 'referrer1', protocol: 'Beefy' },
+      {
+        userAddress: 'user1',
+        timestamp: 1,
+        referrerId: 'referrer1',
+        protocol: 'Beefy',
+      },
+      {
+        userAddress: 'user2',
+        timestamp: 2,
+        referrerId: 'referrer1',
+        protocol: 'Beefy',
+      },
     ])
   })
 })

--- a/scripts/referrals.ts
+++ b/scripts/referrals.ts
@@ -56,7 +56,9 @@ export async function fetchReferralEvents(
             ]
           userAddresses.forEach((userAddress, index) => {
             referralEvents.push({
+              protocol,
               userAddress,
+              referrerId: referrer,
               timestamp: timestamps[index],
             })
           })

--- a/scripts/referrals.ts
+++ b/scripts/referrals.ts
@@ -1,5 +1,3 @@
-// Remove duplicate events, keeping only the earliest event for each user
-
 import { Address } from 'viem'
 import { NetworkId, Protocol, ReferralEvent } from './types'
 import { getRegistryContract } from './utils'
@@ -14,6 +12,7 @@ const NETWORK_ID_TO_REGISTRY_ADDRESS = {
   [NetworkId['base-mainnet']]: '0x0',
 } as Partial<Record<NetworkId, Address>>
 
+// Remove duplicate events, keeping only the earliest event for each user
 export function removeDuplicates(events: ReferralEvent[]): ReferralEvent[] {
   const uniqueEventsMap: Map<string, ReferralEvent> = new Map()
 

--- a/scripts/referrals.ts
+++ b/scripts/referrals.ts
@@ -1,0 +1,69 @@
+// Remove duplicate events, keeping only the earliest event for each user
+
+import { Address } from 'viem'
+import { NetworkId, Protocol, ReferralEvent } from './types'
+import { getRegistryContract } from './utils'
+
+// TODO(ACT-1490): Update this map with the correct registry addresses
+const NETWORK_ID_TO_REGISTRY_ADDRESS = {
+  [NetworkId['ethereum-mainnet']]: '0x0',
+  [NetworkId['arbitrum-one']]: '0x0',
+  [NetworkId['op-mainnet']]: '0x0',
+  [NetworkId['celo-mainnet']]: '0x0',
+  [NetworkId['polygon-pos-mainnet']]: '0x0',
+  [NetworkId['base-mainnet']]: '0x0',
+} as Partial<Record<NetworkId, Address>>
+
+export function removeDuplicates(events: ReferralEvent[]): ReferralEvent[] {
+  const uniqueEventsMap: Map<string, ReferralEvent> = new Map()
+
+  for (const event of events) {
+    const existingEvent = uniqueEventsMap.get(event.userAddress)
+
+    if (!existingEvent || event.timestamp < existingEvent.timestamp) {
+      uniqueEventsMap.set(event.userAddress, event)
+    }
+  }
+
+  return Array.from(uniqueEventsMap.values())
+}
+
+// Fetch all referral events on all networks for the given protocol
+export async function fetchReferralEvents(
+  networkIds: NetworkId[],
+  protocol: Protocol,
+): Promise<ReferralEvent[]> {
+  const referralEvents: ReferralEvent[] = []
+
+  await Promise.all(
+    networkIds.map(async (networkId) => {
+      if (!NETWORK_ID_TO_REGISTRY_ADDRESS[networkId]) {
+        return
+      }
+      const registryContract = await getRegistryContract(
+        NETWORK_ID_TO_REGISTRY_ADDRESS[networkId],
+        networkId,
+      )
+      const referrers = (await registryContract.read.getReferrers([
+        protocol,
+      ])) as string[]
+
+      await Promise.all(
+        referrers.map(async (referrer) => {
+          const [userAddresses, timestamps] =
+            (await registryContract.read.getUsers([protocol, referrer])) as [
+              string[],
+              number[],
+            ]
+          userAddresses.forEach((userAddress, index) => {
+            referralEvents.push({
+              userAddress,
+              timestamp: timestamps[index],
+            })
+          })
+        }),
+      )
+    }),
+  )
+  return referralEvents
+}

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -31,4 +31,6 @@ export type CalculateRevenueFn = (params: {
 export interface ReferralEvent {
   userAddress: string
   timestamp: number
+  referrerId: string
+  protocol: Protocol
 }

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -1,0 +1,63 @@
+import { NetworkId } from './types'
+import { registryContractAbi } from '../abis/Registry'
+import { mainnet, arbitrum, optimism, polygon, base, celo } from 'viem/chains'
+import {
+  createPublicClient,
+  http,
+  getContract,
+  Address,
+  PublicClient,
+} from 'viem'
+
+const NETWORK_ID_TO_VIEM_CLIENT = {
+  [NetworkId['ethereum-mainnet']]: createPublicClient({
+    chain: mainnet,
+    transport: http(),
+  }),
+  [NetworkId['arbitrum-one']]: createPublicClient({
+    chain: arbitrum,
+    transport: http(),
+  }),
+  [NetworkId['op-mainnet']]: createPublicClient({
+    chain: optimism,
+    transport: http(),
+  }),
+  [NetworkId['celo-mainnet']]: createPublicClient({
+    chain: celo,
+    transport: http(),
+  }),
+  [NetworkId['polygon-pos-mainnet']]: createPublicClient({
+    chain: polygon,
+    transport: http(),
+  }),
+  [NetworkId['base-mainnet']]: createPublicClient({
+    chain: base,
+    transport: http(),
+  }),
+} as unknown as Partial<Record<NetworkId, PublicClient>>
+
+/**
+ * Gets a public Viem client for a given NetworkId
+ */
+export function getViemPublicClient(networkId: NetworkId) {
+  const client = NETWORK_ID_TO_VIEM_CLIENT[networkId]
+  if (!client) {
+    throw new Error(`No viem client found for networkId: ${networkId}`)
+  }
+  return client
+}
+
+/**
+ * Returns a contract object representing the registry
+ */
+export async function getRegistryContract(
+  registryAddress: Address,
+  networkId: NetworkId,
+) {
+  const client = getViemPublicClient(networkId)
+  return getContract({
+    address: registryAddress,
+    abi: registryContractAbi,
+    client,
+  })
+}


### PR DESCRIPTION
* fetches referrals from all networks (because if two different frontends both refer a user to a protocol on different chains we need to determine which one did it first)
* removes duplicate referals