### PR TITLE
chore: "shell" mode for deploy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,20 @@ yarn install
 yarn test
 ```
 
+## Local testnet
+
+Run the localtest in one terminal:
+
+```
+yarn hardhat node
+```
+
+And deploy in another:
+
+```
+SHELL=true OWNER_ADDRESS=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 yarn --silent hardhat --network hardhat run scripts/deploy.ts
+```
+
 ## Scripts
 
 ### Fetch Referrals

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -25,6 +25,11 @@ async function getConfig() {
       description: 'Salt to use for CREATE2 deployments',
       type: 'string',
     })
+    .option('shell', {
+      description: 'Print shell commands for deployed conracts to stdout',
+      type: 'boolean',
+      conflicts: ['use-defender'],
+    })
     .option('owner-address', {
       description: 'Address of the address to use as owner',
       type: 'string',
@@ -43,6 +48,7 @@ async function getConfig() {
     useDefender: argv['use-defender'],
     deploySalt: argv['deploy-salt'],
     ownerAddress: argv['owner-address'],
+    shell: argv.shell,
   }
 }
 
@@ -75,15 +81,21 @@ async function main() {
     )
     address = await result.getAddress()
   } else {
-    console.log(`Deploying ${CONTRACT_NAME} with local signer`)
+    if (!config.shell) {
+      console.log(`Deploying ${CONTRACT_NAME} with local signer`)
+    }
     const result = await Registry.deploy(...constructorArgs)
     address = await result.getAddress()
   }
 
-  console.log('\nTo verify the contract, run:')
-  console.log(
-    `yarn hardhat verify ${address} --network ${hre.network.name} ${constructorArgs.join(' ')}`,
-  )
+  if (config.shell) {
+    console.log(`export REGISTRY_ADDRESS=${address}`)
+  } else {
+    console.log('\nTo verify the contract, run:')
+    console.log(
+      `yarn hardhat verify ${address} --network ${hre.network.name} ${constructorArgs.join(' ')}`,
+    )
+  }
 }
 
 // We recommend this pattern to be able to use async/await everywhere


### PR DESCRIPTION
This makes it easier to pipe the environment around. E.g.,

```
eval `yarn hardhat run scripts/deploy.ts`
```