### PR TITLE
chore: update abi and tests

### DIFF
--- a/abis/Registry.ts
+++ b/abis/Registry.ts
@@ -2,14 +2,78 @@ export const registryContractAbi = [
   {
     inputs: [
       {
-        internalType: 'string',
-        name: 'protocolId',
-        type: 'string',
+        internalType: 'address',
+        name: 'owner',
+        type: 'address',
       },
       {
-        internalType: 'string',
+        internalType: 'uint48',
+        name: 'transferDelay',
+        type: 'uint48',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'constructor',
+  },
+  {
+    inputs: [],
+    name: 'AccessControlBadConfirmation',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint48',
+        name: 'schedule',
+        type: 'uint48',
+      },
+    ],
+    name: 'AccessControlEnforcedDefaultAdminDelay',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'AccessControlEnforcedDefaultAdminRules',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'defaultAdmin',
+        type: 'address',
+      },
+    ],
+    name: 'AccessControlInvalidDefaultAdmin',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        internalType: 'bytes32',
+        name: 'neededRole',
+        type: 'bytes32',
+      },
+    ],
+    name: 'AccessControlUnauthorizedAccount',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'protocolId',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'bytes32',
         name: 'referrerId',
-        type: 'string',
+        type: 'bytes32',
       },
     ],
     name: 'ReferrerNotRegistered',
@@ -18,14 +82,30 @@ export const registryContractAbi = [
   {
     inputs: [
       {
-        internalType: 'string',
-        name: 'protocolId',
-        type: 'string',
+        internalType: 'uint8',
+        name: 'bits',
+        type: 'uint8',
       },
       {
-        internalType: 'string',
+        internalType: 'uint256',
+        name: 'value',
+        type: 'uint256',
+      },
+    ],
+    name: 'SafeCastOverflowedUintDowncast',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'protocolId',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'bytes32',
         name: 'referrerId',
-        type: 'string',
+        type: 'bytes32',
       },
       {
         internalType: 'address',
@@ -38,18 +118,68 @@ export const registryContractAbi = [
   },
   {
     anonymous: false,
+    inputs: [],
+    name: 'DefaultAdminDelayChangeCanceled',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'uint48',
+        name: 'newDelay',
+        type: 'uint48',
+      },
+      {
+        indexed: false,
+        internalType: 'uint48',
+        name: 'effectSchedule',
+        type: 'uint48',
+      },
+    ],
+    name: 'DefaultAdminDelayChangeScheduled',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [],
+    name: 'DefaultAdminTransferCanceled',
+    type: 'event',
+  },
+  {
+    anonymous: false,
     inputs: [
       {
         indexed: true,
-        internalType: 'string',
+        internalType: 'address',
+        name: 'newAdmin',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint48',
+        name: 'acceptSchedule',
+        type: 'uint48',
+      },
+    ],
+    name: 'DefaultAdminTransferScheduled',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes32',
         name: 'protocolId',
-        type: 'string',
+        type: 'bytes32',
       },
       {
         indexed: true,
-        internalType: 'string',
+        internalType: 'bytes32',
         name: 'referrerId',
-        type: 'string',
+        type: 'bytes32',
       },
       {
         indexed: true,
@@ -66,15 +196,15 @@ export const registryContractAbi = [
     inputs: [
       {
         indexed: true,
-        internalType: 'string',
+        internalType: 'bytes32',
         name: 'referrerId',
-        type: 'string',
+        type: 'bytes32',
       },
       {
-        indexed: true,
-        internalType: 'string[]',
+        indexed: false,
+        internalType: 'bytes32[]',
         name: 'protocolIds',
-        type: 'string[]',
+        type: 'bytes32[]',
       },
       {
         indexed: false,
@@ -93,19 +223,186 @@ export const registryContractAbi = [
     type: 'event',
   },
   {
+    anonymous: false,
     inputs: [
       {
-        internalType: 'string',
-        name: 'referrerId',
-        type: 'string',
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'role',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'previousAdminRole',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'newAdminRole',
+        type: 'bytes32',
+      },
+    ],
+    name: 'RoleAdminChanged',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'role',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'sender',
+        type: 'address',
+      },
+    ],
+    name: 'RoleGranted',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'role',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'sender',
+        type: 'address',
+      },
+    ],
+    name: 'RoleRevoked',
+    type: 'event',
+  },
+  {
+    inputs: [],
+    name: 'DEFAULT_ADMIN_ROLE',
+    outputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'acceptDefaultAdminTransfer',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'newAdmin',
+        type: 'address',
+      },
+    ],
+    name: 'beginDefaultAdminTransfer',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'cancelDefaultAdminTransfer',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint48',
+        name: 'newDelay',
+        type: 'uint48',
+      },
+    ],
+    name: 'changeDefaultAdminDelay',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'defaultAdmin',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'defaultAdminDelay',
+    outputs: [
+      {
+        internalType: 'uint48',
+        name: '',
+        type: 'uint48',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'defaultAdminDelayIncreaseWait',
+    outputs: [
+      {
+        internalType: 'uint48',
+        name: '',
+        type: 'uint48',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'providerId',
+        type: 'bytes32',
       },
     ],
     name: 'getProtocols',
     outputs: [
       {
-        internalType: 'string[]',
+        internalType: 'bytes32[]',
         name: '',
-        type: 'string[]',
+        type: 'bytes32[]',
       },
     ],
     stateMutability: 'view',
@@ -114,17 +411,17 @@ export const registryContractAbi = [
   {
     inputs: [
       {
-        internalType: 'string',
+        internalType: 'bytes32',
         name: 'protocolId',
-        type: 'string',
+        type: 'bytes32',
       },
     ],
     name: 'getReferrers',
     outputs: [
       {
-        internalType: 'string[]',
+        internalType: 'bytes32[]',
         name: '',
-        type: 'string[]',
+        type: 'bytes32[]',
       },
     ],
     stateMutability: 'view',
@@ -133,9 +430,9 @@ export const registryContractAbi = [
   {
     inputs: [
       {
-        internalType: 'string',
+        internalType: 'bytes32',
         name: 'referrerId',
-        type: 'string',
+        type: 'bytes32',
       },
     ],
     name: 'getRewardAddress',
@@ -152,14 +449,14 @@ export const registryContractAbi = [
   {
     inputs: [
       {
-        internalType: 'string',
+        internalType: 'bytes32',
         name: 'protocolId',
-        type: 'string',
+        type: 'bytes32',
       },
       {
-        internalType: 'string',
+        internalType: 'bytes32',
         name: 'referrerId',
-        type: 'string',
+        type: 'bytes32',
       },
     ],
     name: 'getRewardRate',
@@ -176,14 +473,33 @@ export const registryContractAbi = [
   {
     inputs: [
       {
-        internalType: 'string',
+        internalType: 'bytes32',
+        name: 'role',
+        type: 'bytes32',
+      },
+    ],
+    name: 'getRoleAdmin',
+    outputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
         name: 'protocolId',
-        type: 'string',
+        type: 'bytes32',
       },
       {
-        internalType: 'string',
+        internalType: 'bytes32',
         name: 'referrerId',
-        type: 'string',
+        type: 'bytes32',
       },
     ],
     name: 'getUsers',
@@ -205,17 +521,17 @@ export const registryContractAbi = [
   {
     inputs: [
       {
-        internalType: 'string',
-        name: 'referrerId',
-        type: 'string',
+        internalType: 'bytes32',
+        name: 'role',
+        type: 'bytes32',
       },
       {
-        internalType: 'string',
-        name: 'protocolId',
-        type: 'string',
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
       },
     ],
-    name: 'registerReferral',
+    name: 'grantRole',
     outputs: [],
     stateMutability: 'nonpayable',
     type: 'function',
@@ -223,29 +539,206 @@ export const registryContractAbi = [
   {
     inputs: [
       {
-        internalType: 'string',
-        name: '_referrerId',
-        type: 'string',
+        internalType: 'bytes32',
+        name: 'role',
+        type: 'bytes32',
       },
       {
-        internalType: 'string[]',
-        name: '_protocolIds',
-        type: 'string[]',
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+    ],
+    name: 'hasRole',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'userAddress',
+        type: 'address',
+      },
+      {
+        internalType: 'bytes32[]',
+        name: 'protocolIds',
+        type: 'bytes32[]',
+      },
+    ],
+    name: 'isUserRegistered',
+    outputs: [
+      {
+        internalType: 'bool[]',
+        name: '',
+        type: 'bool[]',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'owner',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'pendingDefaultAdmin',
+    outputs: [
+      {
+        internalType: 'address',
+        name: 'newAdmin',
+        type: 'address',
+      },
+      {
+        internalType: 'uint48',
+        name: 'schedule',
+        type: 'uint48',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'pendingDefaultAdminDelay',
+    outputs: [
+      {
+        internalType: 'uint48',
+        name: 'newDelay',
+        type: 'uint48',
+      },
+      {
+        internalType: 'uint48',
+        name: 'schedule',
+        type: 'uint48',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'referrerId',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'bytes32[]',
+        name: 'protocolIds',
+        type: 'bytes32[]',
+      },
+    ],
+    name: 'registerReferrals',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'referrerId',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'bytes32[]',
+        name: 'protocolIds',
+        type: 'bytes32[]',
       },
       {
         internalType: 'uint256[]',
-        name: '_rewardRates',
+        name: 'rewardRates',
         type: 'uint256[]',
       },
       {
         internalType: 'address',
-        name: '_rewardAddress',
+        name: 'rewardAddress',
         type: 'address',
       },
     ],
     name: 'registerReferrer',
     outputs: [],
     stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'role',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+    ],
+    name: 'renounceRole',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'role',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+    ],
+    name: 'revokeRole',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'rollbackDefaultAdminDelay',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes4',
+        name: 'interfaceId',
+        type: 'bytes4',
+      },
+    ],
+    name: 'supportsInterface',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'view',
     type: 'function',
   },
 ]

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -1,8 +1,8 @@
 /* eslint no-console: 0 */
-import hre from 'hardhat'
-import { loadSecret } from '@valora/secrets-loader'
 import '@nomicfoundation/hardhat-ethers'
 import '@openzeppelin/hardhat-upgrades'
+import { loadSecret } from '@valora/secrets-loader'
+import hre from 'hardhat'
 import yargs from 'yargs'
 
 async function getConfig() {
@@ -98,15 +98,12 @@ async function main() {
     address = await result.getAddress()
   }
 
-  if (config.shell) {
-    console.log(`export REGISTRY_ADDRESS=${address}`)
-    console.log(`export OWNER_ADDRESS=${ownerAddress}`)
-  } else {
-    console.log('\nTo verify the contract, run:')
-    console.log(
-      `yarn hardhat verify ${address} --network ${hre.network.name} ${constructorArgs.join(' ')}`,
-    )
-  }
+  console.log(`export REGISTRY_ADDRESS=${address}`)
+  console.log(`export OWNER_ADDRESS=${ownerAddress}`)
+  console.log('\nTo verify the contract, run:')
+  console.log(
+    `yarn hardhat verify ${address} --network ${hre.network.name} ${constructorArgs.join(' ')}`,
+  )
 }
 
 // We recommend this pattern to be able to use async/await everywhere

--- a/test/Registry.ts
+++ b/test/Registry.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
-import hre from 'hardhat'
 import { getAddress } from 'ethers'
-import { toBytes, bytesToHex } from 'viem'
+import hre from 'hardhat'
+import { stringToHex } from 'viem'
 
 const REGISTRY_CONTRACT_NAME = 'Registry'
 
@@ -12,17 +12,13 @@ const mockRewardAddress2 = getAddress(
   '0x123EcE3750Da237f93B8E339c536989b8978a499'.toLowerCase(),
 )
 const mockReferrerId = 'referrer1'
-const mockReferrerIdBytes = toBytes(mockReferrerId, { size: 32 })
-const mockReferrerIdHex = bytesToHex(mockReferrerIdBytes)
+const mockReferrerIdHex = stringToHex(mockReferrerId, { size: 32 })
 const mockReferrerId2 = 'referrer2'
-const mockReferrerId2Bytes = toBytes(mockReferrerId2, { size: 32 })
-const mockReferrerId2Hex = bytesToHex(mockReferrerId2Bytes)
+const mockReferrerId2Hex = stringToHex(mockReferrerId2, { size: 32 })
 const mockProtocolId = 'protocol1'
-const mockProtocolIdBytes = toBytes(mockProtocolId, { size: 32 })
-const mockProtocolIdHex = bytesToHex(mockProtocolIdBytes)
+const mockProtocolIdHex = stringToHex(mockProtocolId, { size: 32 })
 const mockProtocolId2 = 'protocol2'
-const mockProtocolId2Bytes = toBytes(mockProtocolId2, { size: 32 })
-const mockProtocolId2Hex = bytesToHex(mockProtocolId2Bytes)
+const mockProtocolId2Hex = stringToHex(mockProtocolId2, { size: 32 })
 const mockRewardRates = [10]
 
 describe(REGISTRY_CONTRACT_NAME, function () {
@@ -38,11 +34,11 @@ describe(REGISTRY_CONTRACT_NAME, function () {
   describe('Referrer Registration', function () {
     it('should register a referrer correctly', async function () {
       const { registry } = await deployRegistryContract()
-      const protocolIds = [mockProtocolIdBytes]
+      const protocolIds = [mockProtocolIdHex]
 
       await expect(
         registry.registerReferrer(
-          mockReferrerIdBytes,
+          mockReferrerIdHex,
           protocolIds,
           mockRewardRates,
           mockRewardAddress,
@@ -58,22 +54,22 @@ describe(REGISTRY_CONTRACT_NAME, function () {
 
       // Check that the referrer was registered correctly
       const referrerRewardRate = await registry.getRewardRate(
-        mockProtocolIdBytes,
-        mockReferrerIdBytes,
+        mockProtocolIdHex,
+        mockReferrerIdHex,
       )
       expect(referrerRewardRate).to.equal(10)
 
-      const referrers = await registry.getReferrers(mockProtocolIdBytes)
+      const referrers = await registry.getReferrers(mockProtocolIdHex)
       expect(referrers).to.deep.equal([mockReferrerIdHex])
     })
     it('should register a referrer with multiple protocolIds', async function () {
       const { registry } = await deployRegistryContract()
-      const protocolIds = [mockProtocolIdBytes, mockProtocolId2Bytes]
+      const protocolIds = [mockProtocolIdHex, mockProtocolId2Hex]
       const rewardRates = [10, 20]
 
       await expect(
         registry.registerReferrer(
-          mockReferrerIdBytes,
+          mockReferrerIdHex,
           protocolIds,
           rewardRates,
           mockRewardAddress,
@@ -89,69 +85,65 @@ describe(REGISTRY_CONTRACT_NAME, function () {
 
       // Check that the referrer was registered correctly to protocol1
       const rewardRate1 = await registry.getRewardRate(
-        mockProtocolIdBytes,
-        mockReferrerIdBytes,
+        mockProtocolIdHex,
+        mockReferrerIdHex,
       )
       expect(rewardRate1).to.equal(10)
 
-      const referrersProtocol1 =
-        await registry.getReferrers(mockProtocolIdBytes)
+      const referrersProtocol1 = await registry.getReferrers(mockProtocolIdHex)
       expect(referrersProtocol1).to.deep.equal([mockReferrerIdHex])
 
       // Check that the referrer was registered correctly to protocol2
       const rewardRate2 = await registry.getRewardRate(
-        mockProtocolId2Bytes,
-        mockReferrerIdBytes,
+        mockProtocolId2Hex,
+        mockReferrerIdHex,
       )
       expect(rewardRate2).to.equal(20)
 
-      const referrersProtocol2 =
-        await registry.getReferrers(mockProtocolId2Bytes)
+      const referrersProtocol2 = await registry.getReferrers(mockProtocolId2Hex)
       expect(referrersProtocol2).to.deep.equal([mockReferrerIdHex])
     })
 
     it('should correctly re-register a referrer', async function () {
       const { registry } = await deployRegistryContract()
       await registry.registerReferrer(
-        mockReferrerIdBytes,
-        [mockProtocolIdBytes],
+        mockReferrerIdHex,
+        [mockProtocolIdHex],
         mockRewardRates,
         mockRewardAddress,
       )
 
       // Re-register the referrer with the different protocolIds
       await registry.registerReferrer(
-        mockReferrerIdBytes,
-        [mockProtocolId2Bytes],
+        mockReferrerIdHex,
+        [mockProtocolId2Hex],
         mockRewardRates,
         mockRewardAddress2,
       )
       // Check that the referrer is no longer registered to protocol1
-      const referrersProtocol1 =
-        await registry.getReferrers(mockProtocolIdBytes)
+      const referrersProtocol1 = await registry.getReferrers(mockProtocolIdHex)
       expect(referrersProtocol1).to.deep.equal([])
       // Check that the referrer is now registered to protocol2
-      const referrersProtocol2 =
-        await registry.getReferrers(mockProtocolId2Bytes)
+      const referrersProtocol2 = await registry.getReferrers(mockProtocolId2Hex)
       expect(referrersProtocol2).to.deep.equal([mockReferrerIdHex])
       // Check that the protocol(s) for the referrer has been updated
-      const protocols = await registry.getProtocols(mockReferrerIdBytes)
+      const protocols = await registry.getProtocols(mockReferrerIdHex)
       expect(protocols).to.deep.equal([mockProtocolId2Hex])
       // Check that the referrer's reward address has been updated
-      const rewardAddress = await registry.getRewardAddress(mockReferrerIdBytes)
+      const rewardAddress = await registry.getRewardAddress(mockReferrerIdHex)
       expect(rewardAddress).to.equal(mockRewardAddress2)
     })
 
     it('should allow only the owner to register a referrer', async function () {
       const { registry, addr1 } = await deployRegistryContract()
-      const protocolIds = [mockProtocolIdBytes]
+      const protocolIds = [mockProtocolIdHex]
 
       // Non-owner (addr1) should not be able to register the referrer
       await expect(
         registry
           .connect(addr1)
           .registerReferrer(
-            mockReferrerIdBytes,
+            mockReferrerIdHex,
             protocolIds,
             mockRewardRates,
             mockRewardAddress,
@@ -165,8 +157,8 @@ describe(REGISTRY_CONTRACT_NAME, function () {
       const { registry, addr1 } = await deployRegistryContract()
 
       await registry.registerReferrer(
-        mockReferrerIdBytes,
-        [mockProtocolIdBytes],
+        mockReferrerIdHex,
+        [mockProtocolIdHex],
         mockRewardRates,
         mockRewardAddress,
       )
@@ -174,14 +166,14 @@ describe(REGISTRY_CONTRACT_NAME, function () {
       await expect(
         registry
           .connect(addr1)
-          .registerReferrals(mockReferrerIdBytes, [mockProtocolIdBytes]),
+          .registerReferrals(mockReferrerIdHex, [mockProtocolIdHex]),
       )
         .to.emit(registry, 'ReferralRegistered')
         .withArgs(mockProtocolIdHex, mockReferrerIdHex, addr1.address)
 
       const [userAddresses, timestamps] = await registry.getUsers(
-        mockProtocolIdBytes,
-        mockReferrerIdBytes,
+        mockProtocolIdHex,
+        mockReferrerIdHex,
       )
       expect(userAddresses).to.include(addr1.address)
       expect(timestamps[0]).to.be.above(0)
@@ -189,11 +181,11 @@ describe(REGISTRY_CONTRACT_NAME, function () {
 
     it('should register a referral to multiple protocols', async function () {
       const { registry, addr1 } = await deployRegistryContract()
-      const protocolIds = [mockProtocolIdBytes, mockProtocolId2Bytes]
+      const protocolIds = [mockProtocolIdHex, mockProtocolId2Hex]
       const rewardRates = [10, 20]
 
       await registry.registerReferrer(
-        mockReferrerIdBytes,
+        mockReferrerIdHex,
         protocolIds,
         rewardRates,
         mockRewardAddress,
@@ -202,7 +194,7 @@ describe(REGISTRY_CONTRACT_NAME, function () {
       await expect(
         registry
           .connect(addr1)
-          .registerReferrals(mockReferrerIdBytes, protocolIds),
+          .registerReferrals(mockReferrerIdHex, protocolIds),
       )
         .to.emit(registry, 'ReferralRegistered')
         .withArgs(mockProtocolIdHex, mockReferrerIdHex, addr1.address)
@@ -210,12 +202,12 @@ describe(REGISTRY_CONTRACT_NAME, function () {
         .withArgs(mockProtocolId2Hex, mockReferrerIdHex, addr1.address)
 
       const [userAddressesProtocol1, timestampsProtocol1] =
-        await registry.getUsers(mockProtocolIdBytes, mockReferrerIdBytes)
+        await registry.getUsers(mockProtocolIdHex, mockReferrerIdHex)
       expect(userAddressesProtocol1).to.include(addr1.address)
       expect(timestampsProtocol1[0]).to.be.above(0)
 
       const [userAddressesProtocol2, timestampsProtocol2] =
-        await registry.getUsers(mockProtocolId2Bytes, mockReferrerIdBytes)
+        await registry.getUsers(mockProtocolId2Hex, mockReferrerIdHex)
       expect(userAddressesProtocol2).to.include(addr1.address)
       expect(timestampsProtocol2[0]).to.be.above(0)
     })
@@ -226,7 +218,7 @@ describe(REGISTRY_CONTRACT_NAME, function () {
       await expect(
         registry
           .connect(addr1)
-          .registerReferrals(mockReferrerIdBytes, [mockProtocolIdBytes]),
+          .registerReferrals(mockReferrerIdHex, [mockProtocolIdHex]),
       )
         .to.be.revertedWithCustomError(registry, 'ReferrerNotRegistered')
         .withArgs(mockProtocolIdHex, mockReferrerIdHex)
@@ -236,26 +228,26 @@ describe(REGISTRY_CONTRACT_NAME, function () {
       const { registry, addr1 } = await deployRegistryContract()
 
       await registry.registerReferrer(
-        mockReferrerIdBytes,
-        [mockProtocolIdBytes],
+        mockReferrerIdHex,
+        [mockProtocolIdHex],
         mockRewardRates,
         mockRewardAddress,
       )
       await registry.registerReferrer(
-        mockReferrerId2Bytes,
-        [mockProtocolIdBytes],
+        mockReferrerId2Hex,
+        [mockProtocolIdHex],
         mockRewardRates,
         mockRewardAddress,
       )
       await registry
         .connect(addr1)
-        .registerReferrals(mockReferrerIdBytes, [mockProtocolIdBytes])
+        .registerReferrals(mockReferrerIdHex, [mockProtocolIdHex])
 
       // Trying to register again should revert with custom error "UserAlreadyRegistered"
       await expect(
         registry
           .connect(addr1)
-          .registerReferrals(mockReferrerId2Bytes, [mockProtocolIdBytes]),
+          .registerReferrals(mockReferrerId2Hex, [mockProtocolIdHex]),
       )
         .to.be.revertedWithCustomError(registry, 'UserAlreadyRegistered')
         .withArgs(mockProtocolIdHex, mockReferrerId2Hex, addr1.address)
@@ -265,10 +257,10 @@ describe(REGISTRY_CONTRACT_NAME, function () {
   describe('Getters', function () {
     it('should return whether or not a user is registered with multiple protocols', async function () {
       const { addr1, registry } = await deployRegistryContract()
-      const protocolIds = [mockProtocolIdBytes]
+      const protocolIds = [mockProtocolIdHex]
 
       await registry.registerReferrer(
-        mockReferrerIdBytes,
+        mockReferrerIdHex,
         protocolIds,
         mockRewardRates,
         mockRewardAddress,
@@ -276,60 +268,60 @@ describe(REGISTRY_CONTRACT_NAME, function () {
 
       await registry
         .connect(addr1)
-        .registerReferrals(mockReferrerIdBytes, [mockProtocolIdBytes])
+        .registerReferrals(mockReferrerIdHex, [mockProtocolIdHex])
 
       const referred = await registry.isUserRegistered(addr1, [
-        mockProtocolIdBytes,
-        mockProtocolId2Bytes,
+        mockProtocolIdHex,
+        mockProtocolId2Hex,
       ])
       expect(referred).to.deep.equal([true, false])
     })
 
     it('should return referrers for a protocol', async function () {
       const { registry } = await deployRegistryContract()
-      const protocolIds = [mockProtocolIdBytes]
+      const protocolIds = [mockProtocolIdHex]
 
       await registry.registerReferrer(
-        mockReferrerIdBytes,
+        mockReferrerIdHex,
         protocolIds,
         mockRewardRates,
         mockRewardAddress,
       )
 
-      const referrers = await registry.getReferrers(mockProtocolIdBytes)
+      const referrers = await registry.getReferrers(mockProtocolIdHex)
       expect(referrers).to.deep.equal([mockReferrerIdHex])
     })
 
     it('should return protocols for a referrer', async function () {
       const { registry } = await deployRegistryContract()
-      const protocolIds = [mockProtocolIdBytes]
+      const protocolIds = [mockProtocolIdHex]
 
       await registry.registerReferrer(
-        mockReferrerIdBytes,
+        mockReferrerIdHex,
         protocolIds,
         mockRewardRates,
         mockRewardAddress,
       )
 
-      const protocols = await registry.getProtocols(mockReferrerIdBytes)
+      const protocols = await registry.getProtocols(mockReferrerIdHex)
       expect(protocols).to.deep.equal([mockProtocolIdHex])
     })
 
     it('should return users and their timestamps', async function () {
       const { registry, addr1 } = await deployRegistryContract()
       await registry.registerReferrer(
-        mockReferrerIdBytes,
-        [mockProtocolIdBytes],
+        mockReferrerIdHex,
+        [mockProtocolIdHex],
         mockRewardRates,
         mockRewardAddress,
       )
 
       await registry
         .connect(addr1)
-        .registerReferrals(mockReferrerIdBytes, [mockProtocolIdBytes])
+        .registerReferrals(mockReferrerIdHex, [mockProtocolIdHex])
       const [userAddresses, timestamps] = await registry.getUsers(
-        mockProtocolIdBytes,
-        mockReferrerIdBytes,
+        mockProtocolIdHex,
+        mockReferrerIdHex,
       )
 
       expect(userAddresses).to.include(addr1.address)
@@ -340,15 +332,15 @@ describe(REGISTRY_CONTRACT_NAME, function () {
       const { registry } = await deployRegistryContract()
 
       await registry.registerReferrer(
-        mockReferrerIdBytes,
-        [mockProtocolIdBytes],
+        mockReferrerIdHex,
+        [mockProtocolIdHex],
         mockRewardRates,
         mockRewardAddress,
       )
 
       const rewardRate = await registry.getRewardRate(
-        mockProtocolIdBytes,
-        mockReferrerIdBytes,
+        mockProtocolIdHex,
+        mockReferrerIdHex,
       )
       expect(rewardRate).to.equal(mockRewardRates[0])
     })
@@ -357,13 +349,13 @@ describe(REGISTRY_CONTRACT_NAME, function () {
       const { registry } = await deployRegistryContract()
 
       await registry.registerReferrer(
-        mockReferrerIdBytes,
-        [mockProtocolIdBytes],
+        mockReferrerIdHex,
+        [mockProtocolIdHex],
         mockRewardRates,
         mockRewardAddress,
       )
 
-      const rewardRate = await registry.getRewardAddress(mockReferrerIdBytes)
+      const rewardRate = await registry.getRewardAddress(mockReferrerIdHex)
       expect(rewardRate).to.equal(mockRewardAddress)
     })
   })


### PR DESCRIPTION
This PR does a couple of small things:
- update the abi to account for the latest contract changes
- update the Registry tests to use `stringToHex` for the byte32 type conversion (`toBytes` returns a `ByteArray` which is causes typescript errors when used with `encodeFunctionData`)
- ensure command to verify contract is always printed for the deploy script as folks may want to verify the contracts when deployed locally

Note that we need to add `as const` to the end of the abi variable, but I did not do that here because it generates too many errors (the funding scripts all need to be updated to account for the contract changes, I spent some time on this but wasn't sure I was making the best changes)