### PR TITLE
chore: ignore reward folder

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,6 @@ package.json
 
 # Ignore generated dist folder
 dist
+
+# Ignore rewards folder
+rewards


### PR DESCRIPTION
### Description

Ignores the generated rewards folder from prettier styles -- these files are automatically generated.