### PR TITLE
fix: lower defiLlama rate limit

### DIFF
--- a/scripts/calculateKpi/protocols/utils/events.ts
+++ b/scripts/calculateKpi/protocols/utils/events.ts
@@ -52,8 +52,8 @@ async function _getNearestBlock(
 
 // Set up a Bottleneck instance to keep requests to DefiLlama under the allowed rate limit (500 requests per minute).
 const limiter = new Bottleneck({
-  reservoir: 450, // initial number of available requests
-  reservoirRefreshAmount: 450, // how many tokens to add on refresh
+  reservoir: 200, // initial number of available requests
+  reservoirRefreshAmount: 200, // how many tokens to add on refresh
   reservoirRefreshInterval: 60 * 1000, // refresh every 60 seconds
   minTime: 0, // no minimum time between requests
 })


### PR DESCRIPTION
Last time I was researching, I thought that I saw 500/min as the rate limit. But according to [this page](https://docs.llama.fi/pro-api#open-free), it is 10-200 on a free plan. I am seeing some failures in the calculation after merging the latest change, although the same change was working last night :/ lowering it to 200 here to minimise flake.

Related to ENG-414