### PR TITLE
chore: DivviRegistry staging upgrade deployment

### DIFF
--- a/.openzeppelin/optimism.json
+++ b/.openzeppelin/optimism.json
@@ -12,6 +12,10 @@
       "txHash": "0x1310cfdfecf7996e5d0d6d01f79f056671f79c81c1faafb364a67398053f6c08",
       "remoteDeploymentId": "4f89de60-4ad7-46f8-9ad6-4619152f14cf",
       "kind": "uups"
+    },
+    {
+      "address": "0x2f5E320698dB89CbefB810Fa19264103d99aAFB1",
+      "kind": "uups"
     }
   ],
   "impls": {
@@ -750,6 +754,269 @@
               "slot": "0"
             }
           ],
+          "erc7201:openzeppelin.storage.AccessControlDefaultAdminRules": [
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_pendingDefaultAdmin",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlDefaultAdminRulesUpgradeable.sol:45",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_pendingDefaultAdminSchedule",
+              "type": "t_uint48",
+              "src": "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlDefaultAdminRulesUpgradeable.sol:46",
+              "offset": 20,
+              "slot": "0"
+            },
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_currentDelay",
+              "type": "t_uint48",
+              "src": "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlDefaultAdminRulesUpgradeable.sol:48",
+              "offset": 26,
+              "slot": "0"
+            },
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_currentDefaultAdmin",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlDefaultAdminRulesUpgradeable.sol:49",
+              "offset": 0,
+              "slot": "1"
+            },
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_pendingDelay",
+              "type": "t_uint48",
+              "src": "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlDefaultAdminRulesUpgradeable.sol:52",
+              "offset": 20,
+              "slot": "1"
+            },
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_pendingDelaySchedule",
+              "type": "t_uint48",
+              "src": "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlDefaultAdminRulesUpgradeable.sol:53",
+              "offset": 26,
+              "slot": "1"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+              "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "22d5313a1a6755ecc8d4b972ebe7c9f2e4be5b7ec83ee1a21610c34daffd6838": {
+      "address": "0xAB7dc5EFa0A3a9c3e5eE4DdD0dcF641Cb06F5813",
+      "remoteDeploymentId": "8fa762d5-5e2e-4ddb-a909-ce865ebbbc9d",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [
+          {
+            "label": "_entities",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_mapping(t_address,t_struct(EntityData)6271_storage)",
+            "contract": "DivviRegistry",
+            "src": "contracts/DivviRegistry.sol:87"
+          },
+          {
+            "label": "_agreements",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "DivviRegistry",
+            "src": "contracts/DivviRegistry.sol:90"
+          },
+          {
+            "label": "_registeredReferrals",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_mapping(t_bytes32,t_address)",
+            "contract": "DivviRegistry",
+            "src": "contracts/DivviRegistry.sol:93"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)24_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlDefaultAdminRulesStorage)175_storage": {
+            "label": "struct AccessControlDefaultAdminRulesUpgradeable.AccessControlDefaultAdminRulesStorage",
+            "members": [
+              {
+                "label": "_pendingDefaultAdmin",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_pendingDefaultAdminSchedule",
+                "type": "t_uint48",
+                "offset": 20,
+                "slot": "0"
+              },
+              {
+                "label": "_currentDelay",
+                "type": "t_uint48",
+                "offset": 26,
+                "slot": "0"
+              },
+              {
+                "label": "_currentDefaultAdmin",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "_pendingDelay",
+                "type": "t_uint48",
+                "offset": 20,
+                "slot": "1"
+              },
+              {
+                "label": "_pendingDelaySchedule",
+                "type": "t_uint48",
+                "offset": 26,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(AccessControlStorage)34_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)432_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)24_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint48": {
+            "label": "uint48",
+            "numberOfBytes": "6"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_mapping(t_address,t_struct(EntityData)6271_storage)": {
+            "label": "mapping(address => struct DivviRegistry.EntityData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_address)": {
+            "label": "mapping(bytes32 => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_bool)": {
+            "label": "mapping(bytes32 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(EntityData)6271_storage": {
+            "label": "struct DivviRegistry.EntityData",
+            "members": [
+              {
+                "label": "exists",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "requiresApproval",
+                "type": "t_bool",
+                "offset": 1,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          }
+        },
+        "namespaces": {
           "erc7201:openzeppelin.storage.AccessControlDefaultAdminRules": [
             {
               "contract": "AccessControlDefaultAdminRulesUpgradeable",

--- a/README.md
+++ b/README.md
@@ -173,6 +173,17 @@ yarn hardhat divvi-registry:upgrade \
     --proxy-address <PROXY_ADDRESS>
 ```
 
+To upgrade the staging DivviRegistry, you need to specify the approval process ID:
+
+```bash
+yarn hardhat divvi-registry:upgrade \
+    --network op \
+    --use-defender \
+    --defender-deploy-salt <SALT> \
+    --defender-upgrade-approval-process-id f1d0a27d-c2f1-4f87-b36c-d3c308283702 \
+    --proxy-address 0x2f5E320698dB89CbefB810Fa19264103d99aAFB1
+```
+
 ### Metadata of upgradable contracts
 
 Metadata about proxy and implementation deployments is automatically generated and stored in the `.openzeppelin/` directory, which should be checked into version control.

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -26,7 +26,8 @@ Owner address: [0xfC95675a6bB93406C0CbBa9403a084Dd8D566F06](https://app.safe.glo
 
 ## Staging
 
-Proxy address:[0x2f5E320698dB89CbefB810Fa19264103d99aAFB1](https://optimistic.etherscan.io/address/0x2f5E320698dB89CbefB810Fa19264103d99aAFB1)
+Proxy address: [0x2f5E320698dB89CbefB810Fa19264103d99aAFB1](https://optimistic.etherscan.io/address/0x2f5E320698dB89CbefB810Fa19264103d99aAFB1)
+
 Owner address: [0x8CA1cCe5c6420502d61e56eE69521b7F03eEFc8C](https://app.safe.global/home?safe=oeth:0x8CA1cCe5c6420502d61e56eE69521b7F03eEFc8C)
 
 ## Reward Pool Contract

--- a/tasks/divviRegistry.ts
+++ b/tasks/divviRegistry.ts
@@ -40,9 +40,15 @@ task('divvi-registry:upgrade', 'Upgrade DivviRegistry contract')
   .addParam('proxyAddress', 'Address of the DivviRegistry proxy')
   .addFlag('useDefender', 'Deploy using OpenZeppelin Defender')
   .addOptionalParam('defenderDeploySalt', 'Salt to use for CREATE2 deployments')
+  .addOptionalParam(
+    'defenderUpgradeApprovalProcessId',
+    'Defender approval process ID to use for upgrades (if not provided, will use the default approval process set in Defender)',
+  )
   .setAction(async (taskArgs, hre) => {
     await upgradeContract(hre, CONTRACT_NAME, taskArgs.proxyAddress, {
       useDefender: taskArgs.useDefender,
       defenderDeploySalt: taskArgs.defenderDeploySalt,
+      defenderUpgradeApprovalProcessId:
+        taskArgs.defenderUpgradeApprovalProcessId,
     })
   })

--- a/tasks/helpers/deployHelpers.ts
+++ b/tasks/helpers/deployHelpers.ts
@@ -25,11 +25,13 @@ type DefenderConfig = WithDefender | WithoutDefender
 type WithDefender = {
   useDefender: true
   defenderDeploySalt?: string
+  defenderUpgradeApprovalProcessId?: string // if not provided, will use the default approval process set in Defender
 }
 
 type WithoutDefender = {
   useDefender?: false
   defenderDeploySalt?: never
+  approvalProcessId?: never
 }
 
 // Contract deployment helper
@@ -148,6 +150,10 @@ export async function upgradeContract(
 
   if (config?.useDefender) {
     console.log(`Upgrading ${contractName} with OpenZeppelin Defender`)
+    console.log(
+      'Approval process ID:',
+      config.defenderUpgradeApprovalProcessId || 'default',
+    )
     console.log(`Proxy Address: ${proxyAddress}`)
 
     const currentImplementationAddress = await getImplementationAddress(
@@ -160,6 +166,7 @@ export async function upgradeContract(
       proxyAddress,
       Contract,
       {
+        approvalProcessId: config.defenderUpgradeApprovalProcessId,
         salt: config.defenderDeploySalt,
       },
     )


### PR DESCRIPTION
This is the DivviRegistry staging upgrade deployment done with Defender.

Because we didn't initially deploy it with Defender I had to [force import](https://docs.openzeppelin.com/upgrades-plugins/api-hardhat-upgrades#force-import) it first:

```ts
console.log('Force importing...')
const result = await hre.defender.forceImport(proxyAddress, Contract, {
 kind: 'uups',
})
console.log('Result:', result)
```

Note: after doing this, and trying to upgrade, it was still trying to set the upgraded implementation to the existing one. I forced the redeploy of the implementation using `redeployImplementation: 'always'` and was then able to correctly upgrade.

Then, because the owner on the DivviRegistry staging contract is different, I needed a new approval process on Defender with it.
So I needed a way to specify the approval process ID instead of using the default one (which we should probably not set by the way, as it's a bit confusing if we're using different owners).

So I added an new option for that.