### PR TITLE
chore(calculate-and-upload-KPIs): update schedule

### DIFF
--- a/.github/workflows/calculate-and-upload-KPIs.yaml
+++ b/.github/workflows/calculate-and-upload-KPIs.yaml
@@ -2,7 +2,7 @@ name: Calculate and Upload KPIs
 
 on:
   schedule:
-    - cron: '0 * * * *' # Runs at minute 0 of every hour
+    - cron: '0 */2 * * *' # Runs at minute 0 every 2 hours
   workflow_dispatch:
     inputs:
       timestamp:


### PR DESCRIPTION
Some runs take longer than 1h, which end up getting cancelled by the new run. So reducing the frequency to give enough time for a run to complete