### PR TITLE
chore: Run kpi script every 2 hours

### DIFF
--- a/.github/workflows/calculate-and-upload-KPIs.yaml
+++ b/.github/workflows/calculate-and-upload-KPIs.yaml
@@ -2,7 +2,7 @@ name: Calculate and Upload KPIs
 
 on:
   schedule:
-    - cron: '0 * * * *' # Runs at minute 0 every hour
+    - cron: '0 */2 * * *' # Runs at minute 0 every 2 hours
   workflow_dispatch:
     inputs:
       timestamp:


### PR DESCRIPTION
Tether campaign is big and run time was getting close to 1 hr, so bumped up to running every 2 hours to make sure it finishes.

[Ticket](https://linear.app/valora/issue/ENG-608/tether-campaign-optimization-do-1-hypersync-call-for-multiple-users) made for further optimization to be able to go back down to every hour.