### PR TITLE
chore: update celo pg 1 cycle 3 exclude list

### DIFF
--- a/src/campaigns.ts
+++ b/src/campaigns.ts
@@ -165,6 +165,16 @@ const excludedReferrersFromCeloPGS1 = [
     '0x2298947e6c1d6c282c258b3e5f8989670a8e346f', // Dezenmart
     '0xda404bfda2a5dcda88fd2aa9b9e0c32a677bc8eb', // Contriboost
   ]),
+  excludeRecord([
+    '0x37b5a29b9532940414bbc59c616696daba16169c', // FunBear
+    '0xe70ffe8d559207261a17834c58786bfd53cd8642', // Doeg
+    '0xba7a463cf9f68046311616bb4c787923828f0644', // Premio
+    '0x3207d4728c32391405c7122e59ccb115a4af31ea', // HealFi
+    '0x10265305e8b7ce057d70875f0fd44f2ee48456cb', // Spinit
+    '0xd7c271d20c9e323336bfc843aeb8dec23b346352', // Learna
+    '0x2298947e6c1d6c282c258b3e5f8989670a8e346f', // Dezenmart
+    '0xda404bfda2a5dcda88fd2aa9b9e0c32a677bc8eb', // Contriboost
+  ]),
 ]
 
 const tetherV0Campaign: Campaign = {
@@ -338,7 +348,7 @@ const celoPGS1Campaign: Campaign = {
         const index = 2
         const mergedExcludedReferrers = await getMergedExcludedReferrers(
           celoPGS1Campaign.providerAddress,
-          excludedReferrersFromCeloPGS1[1],
+          excludedReferrersFromCeloPGS1[2],
         )
         await calculateRewardsCeloPGS1({
           resultDirectory,
@@ -362,7 +372,7 @@ const celoPGS1Campaign: Campaign = {
         const index = 3
         const mergedExcludedReferrers = await getMergedExcludedReferrers(
           celoPGS1Campaign.providerAddress,
-          excludedReferrersFromCeloPGS1[1],
+          excludedReferrersFromCeloPGS1[2],
         )
         await calculateRewardsCeloPGS1({
           resultDirectory,
@@ -387,7 +397,7 @@ const celoPGS1Campaign: Campaign = {
         const index = 4
         const mergedExcludedReferrers = await getMergedExcludedReferrers(
           celoPGS1Campaign.providerAddress,
-          excludedReferrersFromCeloPGS1[1],
+          excludedReferrersFromCeloPGS1[2],
         )
         await calculateRewardsCeloPGS1({
           resultDirectory,
@@ -412,7 +422,7 @@ const celoPGS1Campaign: Campaign = {
         const index = 5
         const mergedExcludedReferrers = await getMergedExcludedReferrers(
           celoPGS1Campaign.providerAddress,
-          excludedReferrersFromCeloPGS1[1],
+          excludedReferrersFromCeloPGS1[2],
         )
         await calculateRewardsCeloPGS1({
           resultDirectory,
@@ -437,7 +447,7 @@ const celoPGS1Campaign: Campaign = {
         const index = 6
         const mergedExcludedReferrers = await getMergedExcludedReferrers(
           celoPGS1Campaign.providerAddress,
-          excludedReferrersFromCeloPGS1[1],
+          excludedReferrersFromCeloPGS1[2],
         )
         await calculateRewardsCeloPGS1({
           resultDirectory,
@@ -462,7 +472,7 @@ const celoPGS1Campaign: Campaign = {
         const index = 7
         const mergedExcludedReferrers = await getMergedExcludedReferrers(
           celoPGS1Campaign.providerAddress,
-          excludedReferrersFromCeloPGS1[1],
+          excludedReferrersFromCeloPGS1[2],
         )
         await calculateRewardsCeloPGS1({
           resultDirectory,


### PR DESCRIPTION
Remove 'Sovseas' from the Celo PG 1 exclude list for cycle 3 and all future cycles to comply with ENG-669.

---
Linear Issue: [ENG-669](https://linear.app/valora/issue/ENG-669/update-exclude-list-for-celo-pg-1-cycle-3)

<a href="https://cursor.com/background-agent?bcId=bc-a9ecb740-0271-4cee-88ed-95cb238165cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a9ecb740-0271-4cee-88ed-95cb238165cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

